### PR TITLE
Fix crash on publishing GeometryMsg.

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.cpp
@@ -16,6 +16,7 @@ bool UGeometryMsgsQuaternionConverter::ConvertOutgoingMessage(TSharedPtr<FROSBas
 
 	auto Quaternion = StaticCastSharedPtr<ROSMessages::geometry_msgs::Quaternion>(BaseMsg);
 
+	*message = new bson_t;
 	bson_init(*message);
 	_bson_append_quaternion(*message, Quaternion.Get());
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.cpp
@@ -16,6 +16,7 @@ bool UGeometryMsgsTransformConverter::ConvertOutgoingMessage(TSharedPtr<FROSBase
 
 	auto Transform = StaticCastSharedPtr<ROSMessages::geometry_msgs::Transform>(BaseMsg);
 
+	*message = new bson_t;
 	bson_init(*message);
 	_bson_append_transform(*message, Transform.Get());
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.cpp
@@ -19,6 +19,7 @@ bool UGeometryMsgsTransformStampedConverter::ConvertOutgoingMessage(TSharedPtr<F
 	
 	auto TransformStamped = StaticCastSharedPtr<ROSMessages::geometry_msgs::TransformStamped>(BaseMsg);
 
+	*message = new bson_t;
 	bson_init(*message);
 	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(TransformStamped->header));
 	BSON_APPEND_UTF8(*message, "child_frame_id", TCHAR_TO_UTF8(*TransformStamped->child_frame_id));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.cpp
@@ -17,6 +17,7 @@ bool UGeometryMsgsVector3Converter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMs
 	
 	auto Vector3 = StaticCastSharedPtr<ROSMessages::geometry_msgs::Vector3>(BaseMsg);
 
+	*message = new bson_t;
 	bson_init(*message);
 	_bson_append_vector3(*message, Vector3.Get());
 	


### PR DESCRIPTION
Apparently creating a new bson_t before initializing is enough here.
Please mind that I have no experience with BSON, so this might not be the intended solution. A quick test showed that I can now send geometry messages without problems though.
This would fix issue #20 