### PR TITLE
Make it possible to send a standalone std_msgs/Header.

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.cpp
@@ -18,8 +18,16 @@ bool UStdMsgsHeaderConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* 
 
 bool UStdMsgsHeaderConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
 {
-	auto ConcreteMessage = StaticCastSharedPtr<ROSMessages::std_msgs::Header>(BaseMsg);
-	_bson_append_header(*message, ConcreteMessage.Get());
+	auto h = StaticCastSharedPtr<ROSMessages::std_msgs::Header>(BaseMsg);
+
+	*message = BCON_NEW(
+		"seq", BCON_INT32(h->seq),
+		"stamp", "{",
+		"secs", BCON_INT32(h->time._Sec),
+		"nsecs", BCON_INT32(h->time._NSec),
+		"}",
+		"frame_id", BCON_UTF8(TCHAR_TO_ANSI(*h->frame_id))
+	);
 
 	return true;
 }


### PR DESCRIPTION
Currently, with the way std_msgs/Header is being converted to BSON, it is not possible to send a message with just a header. This PR adds a conversion that does not interfere with the usual, embedded headers, but reads standalone headers just fine.