### PR TITLE
Build.cs: Definitions -> PublicDefinitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This plugin has been tested with Unreal Engine versions;
  * 4.17.3
  * 4.18.2
  * 4.18.3
- * 4.19.1
+ * 4.19.1, 4.19.2
 
 ## Usage
 

--- a/Source/ROSIntegration/ROSIntegration.Build.cs
+++ b/Source/ROSIntegration/ROSIntegration.Build.cs
@@ -29,9 +29,12 @@ public class ROSIntegration : ModuleRules
         // Console.WriteLine("");
         Console.WriteLine("BSONPath: " + BSONPath);
 
-        // Include std::string functions for rapidjson
-        Definitions.Add("RAPIDJSON_HAS_STDSTRING=1");
-
+		// Include std::string functions for rapidjson
+#if UE_4_19_OR_LATER // works at least for 4.18.3, but not for 4.17.3 and below
+		PublicDefinitions.Add("RAPIDJSON_HAS_STDSTRING=1");
+#else
+		Definitions.Add("RAPIDJSON_HAS_STDSTRING=1");
+#endif
 
         PublicIncludePaths.AddRange(
 			new string[] {


### PR DESCRIPTION
**UE 4.19.2** and **Visual Studio 2015** create an error while generating the Visual Studio Solution, because of the keyword ```Definitions``` in Source/ROSIntegration/ROSIntegration.Build.cs.

The keyword ```PublicDefinitions``` ist tested sucessfully with 4.18.3 and 4.19.2. It definitly does not work with 4.16.3 and 4.17.2. That's why I added the macro **UE_4_19_OR_LATER**.