### PR TITLE
Last commit introduced a compiler error

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.h
@@ -34,7 +34,6 @@ public:
 
 		uint32_t binSize = 0;
 		img->data_ptr = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*(key + ".data")), *b, binSize, KeyFound);
-		img->data = TArray<uint8_t>(img->data_ptr, img->height * img->step);
 
 		return KeyFound;
 	}


### PR DESCRIPTION
due to the 'data'-field in sensor_msgs/Image being removed.

I think we should discuss whether it's a good idea to diverge from the naming of fields in the original message definition. We have no field "data" in this message anymore, only the data_ptr. Imho we should either call the data_ptr "data" now or reintroduce the data-field as a TArray. What was the reason to remove the TArray data in the first place? As far as I know it doesn't really impact speed or memory when handled correctly.