### PR TITLE
Add support for 2 standard nav_msgs

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
@@ -114,6 +114,11 @@ public:
 		// bson doesn't support float, only double. So we use GetDoubleFromBSON internally
 		return GetTArrayFromBSON<float>(Key, msg, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetDoubleFromBSON(subKey, subMsg, subKeyFound, false); }, LogOnErrors);
 	}
+	
+	static TArray<int32> GetInt32TArrayFromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
+	{
+		return GetTArrayFromBSON<int32>(Key, msg, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetInt32FromBSON(subKey, subMsg, subKeyFound, false); }, LogOnErrors);
+	}
 
 protected:
 
@@ -152,6 +157,12 @@ protected:
 		_bson_append_uint32_tarray(b, key, (TArray<uint32>)tarray);
 	}
 
+	// Helper function to append a TArray<int32> to a bson_t
+	static void _bson_append_int32_tarray(bson_t *b, const char *key, const TArray<int32>& tarray)
+	{
+		_bson_append_tarray<int32>(b, key, tarray, [](bson_t *subb, const char *subKey, int32 i) { BSON_APPEND_INT32(subb, subKey, i); });
+	}
+	
 	// Helper function to append a TArray<uint32> to a bson_t
 	static void _bson_append_uint32_tarray(bson_t *b, const char *key, const TArray<uint32>& tarray)
 	{

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.cpp
@@ -1,0 +1,29 @@
+#include "NavMsgsMapMetaDataConverter.h"
+
+#include "nav_msgs/MapMetaData.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
+
+
+UNavMsgsMapMetaDataConverter::UNavMsgsMapMetaDataConverter(const FObjectInitializer& ObjectInitializer)
+: Super(ObjectInitializer)
+{
+	_MessageType = "nav_msgs/MapMetaData";
+}
+
+bool UNavMsgsMapMetaDataConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
+{
+	auto p = new ROSMessages::nav_msgs::MapMetaData;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
+	return _bson_extract_child_map_meta_data(message->full_msg_bson_, "msg", p);
+}
+
+bool UNavMsgsMapMetaDataConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
+{
+	auto map = StaticCastSharedPtr<ROSMessages::nav_msgs::MapMetaData>(BaseMsg);
+	
+	*message = new bson_t;
+	bson_init(*message);
+	_bson_append_map_meta_data(*message, map.Get());
+	
+	return true;
+}

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <UObject/ObjectMacros.h>
+#include <UObject/Object.h>
+#include "Conversion/Messages/BaseMessageConverter.h"
+#include "nav_msgs/MapMetaData.h"
+#include "NavMsgsMapMetaDataConverter.generated.h"
+
+
+UCLASS()
+class ROSINTEGRATION_API UNavMsgsMapMetaDataConverter : public UBaseMessageConverter
+{
+	GENERATED_UCLASS_BODY()
+	
+public:
+	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
+	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+	
+	// Helper function to extract a child-std_msgs/Header from a bson_t
+	static bool _bson_extract_child_map_meta_data(bson_t *b, FString key, ROSMessages::nav_msgs::MapMetaData *mmd)
+	{
+		bool KeyFound = false;
+		int32 Sec =  GetInt32FromBSON(key + ".map_load_time.secs",  b, KeyFound);  if (!KeyFound) return false;
+		int32 NSec = GetInt32FromBSON(key + ".map_load_time.nsecs", b, KeyFound); if (!KeyFound) return false;
+		mmd->map_load_time = FROSTime(Sec, NSec);
+		
+		mmd->resolution = (float)GetDoubleFromBSON(key + ".resolution", b, KeyFound);  if (!KeyFound) return false;
+		
+		mmd->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
+		mmd->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
+		
+		if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".origin", &mmd->origin)) return false;
+		
+		return true;
+	}
+	
+	static void _bson_append_child_map_meta_data(bson_t *b, const char *key, ROSMessages::nav_msgs::MapMetaData *mmd)
+	{
+		bson_t mapmetadata;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &mapmetadata);
+		_bson_append_map_meta_data(&mapmetadata, mmd);
+		bson_append_document_end(b, &mapmetadata);
+	}
+	
+	static void _bson_append_map_meta_data(bson_t *b, ROSMessages::nav_msgs::MapMetaData *mmd)
+	{
+		bson_t map_load_time;
+		BSON_APPEND_DOCUMENT_BEGIN(b, "map_load_time", &map_load_time);
+		BSON_APPEND_INT32(&map_load_time, "secs",  mmd->map_load_time._Sec);
+		BSON_APPEND_INT32(&map_load_time, "nsecs", mmd->map_load_time._NSec);
+		bson_append_document_end(b, &map_load_time);
+		
+		BSON_APPEND_DOUBLE(b, "resolution", mmd->resolution);
+		
+		BSON_APPEND_INT32(b, "width",  mmd->width);
+		BSON_APPEND_INT32(b, "height", mmd->height);
+		
+		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "origin", &(mmd->origin));
+	}
+	
+};
+

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.cpp
@@ -1,0 +1,47 @@
+#include "NavMsgsOccupancyGridConverter.h"
+
+#include "nav_msgs/OccupancyGrid.h"
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "NavMsgsMapMetaDataConverter.h"
+
+UNavMsgsOccupancyGridConverter::UNavMsgsOccupancyGridConverter(const FObjectInitializer& ObjectInitializer)
+: Super(ObjectInitializer)
+{
+	_MessageType = "nav_msgs/OccupancyGrid";
+}
+
+bool UNavMsgsOccupancyGridConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
+{
+	auto o = new ROSMessages::nav_msgs::OccupancyGrid();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(o);
+	
+	bool KeyFound = false;
+	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &o->header);
+	if (!KeyFound) return false;
+	
+	KeyFound = UNavMsgsMapMetaDataConverter::_bson_extract_child_map_meta_data(message->full_msg_bson_, TEXT("msg.info"), &o->info);
+	if (!KeyFound) return false;
+	
+	o->data = GetInt32TArrayFromBSON(TEXT("msg.data"), message->full_msg_bson_, KeyFound);
+	if (!KeyFound) return false;
+	
+	return true;
+}
+
+bool UNavMsgsOccupancyGridConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
+{
+	auto grid = StaticCastSharedPtr<ROSMessages::nav_msgs::OccupancyGrid>(BaseMsg);
+	
+	*message = new bson_t;
+	bson_init(*message);
+	
+	UStdMsgsHeaderConverter::_bson_append_header(*message, &(grid->header));
+	
+	UNavMsgsMapMetaDataConverter::_bson_append_child_map_meta_data(*message, "info", &(grid->info));
+	
+	_bson_append_int32_tarray(*message, "data", grid->data);
+	
+	return true;
+}
+
+

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <UObject/ObjectMacros.h>
+#include <UObject/Object.h>
+#include "Conversion/Messages/BaseMessageConverter.h"
+
+#include "NavMsgsOccupancyGridConverter.generated.h"
+
+
+UCLASS()
+class ROSINTEGRATION_API UNavMsgsOccupancyGridConverter : public UBaseMessageConverter
+{
+	GENERATED_UCLASS_BODY()
+	
+public:
+	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
+	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+};

--- a/Source/ROSIntegration/Public/nav_msgs/MapMetaData.h
+++ b/Source/ROSIntegration/Public/nav_msgs/MapMetaData.h
@@ -1,0 +1,50 @@
+//
+//  MapMetaData.h
+//  HFS
+//
+//  Created by Timothy Saucer on 2/19/19.
+//  Copyright © 2019 Epic Games, Inc. All rights reserved.
+//
+
+#pragma once
+
+#include "ROSBaseMsg.h"
+#include "geometry_msgs/Pose.h"
+
+namespace ROSMessages {
+    namespace nav_msgs {
+        class MapMetaData : public FROSBaseMsg {
+        public:
+            MapMetaData() {
+                _MessageType = "nav_msgs/MapMetaData";
+            }
+            
+            MapMetaData(FROSTime map_load_time, float resolution, uint32 width, uint32 height, geometry_msgs::Pose origin) : map_load_time(map_load_time), resolution(resolution), width(width), height(height), origin(origin)
+            {
+                _MessageType = "nav_msgs/MapMetaData";
+            }
+            
+            // time map_load_time
+            FROSTime map_load_time;
+            
+            //float32 resolution
+            float resolution;
+            
+            //uint32 width
+            uint32 width;
+            
+            //uint32 height
+            uint32 height;
+            
+            //geometry_msgs/Pose origin
+            geometry_msgs::Pose origin;
+        };
+    }
+}
+
+
+//time map_load_time
+//float32 resolution
+//uint32 width
+//uint32 height
+//geometry_msgs/Pose origin

--- a/Source/ROSIntegration/Public/nav_msgs/OccupancyGrid.h
+++ b/Source/ROSIntegration/Public/nav_msgs/OccupancyGrid.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "ROSBaseMsg.h"
+
+#include "std_msgs/Header.h"
+#include "nav_msgs/MapMetaData.h"
+
+namespace ROSMessages {
+    namespace nav_msgs {
+        class OccupancyGrid : public FROSBaseMsg {
+        public:
+            OccupancyGrid() {
+                _MessageType = "nav_msgs/OccupancyGrid";
+            }
+            
+            // Header header
+            std_msgs::Header header;
+            
+            // nav_msgs/MapMetaData info
+            MapMetaData info;
+            
+            // int8[] data
+            // Note: BSON will coerce the int32 to int8. int8 not implemented in BSON.
+            TArray<int32> data;
+        };
+    }
+}


### PR DESCRIPTION
Please review the proposed additions. They add support for bson conversion of int arrays as well as two standard messages: nav_msgs/MapMetaData and nav_msgs/OccupancyGrid.

I've tested these against UE4.20 with ros melodic and successfully passed the messages both directions. For the project I am working on, I may have other standard messages I will need to add. If you add me to the main repository, I would prefer to push the additions to a branch there instead of a fork.