### PR TITLE
Add const to ROSMessage pointer in _bson_append_... to make them usable for _bson_append_tarray

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h
@@ -28,7 +28,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_goal_id(bson_t *b, const char *key, ROSMessages::actionlib_msgs::GoalID *g)
+	static void _bson_append_child_goal_id(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalID *g)
 	{
 		bson_t goalID;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &goalID);
@@ -36,7 +36,7 @@ public:
 		bson_append_document_end(b, &goalID);
 	}
 
-	static void _bson_append_goal_id(bson_t *b, ROSMessages::actionlib_msgs::GoalID *g)
+	static void _bson_append_goal_id(bson_t *b, const ROSMessages::actionlib_msgs::GoalID *g)
 	{
 		bson_t stamp;
 		BSON_APPEND_DOCUMENT_BEGIN(b, "stamp", &stamp);

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h
@@ -35,7 +35,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_goal_status_array(bson_t *b, const char *key, ROSMessages::actionlib_msgs::GoalStatusArray *g)
+	static void _bson_append_child_goal_status_array(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatusArray *g)
 	{
 		bson_t array;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &array);
@@ -43,7 +43,7 @@ public:
 		bson_append_document_end(b, &array);
 	}
 
-	static void _bson_append_goal_status_array(bson_t *b, ROSMessages::actionlib_msgs::GoalStatusArray *g)
+	static void _bson_append_goal_status_array(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatusArray *g)
 	{
 		UStdMsgsHeaderConverter::_bson_append_header(b, &(g->header));
 		_bson_append_tarray<ROSMessages::actionlib_msgs::GoalStatus>(b, "status_list", g->status_list, [](bson_t *subb, const char *subKey, ROSMessages::actionlib_msgs::GoalStatus gs)

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h
@@ -28,7 +28,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_goal_status(bson_t *b, const char *key, ROSMessages::actionlib_msgs::GoalStatus *g)
+	static void _bson_append_child_goal_status(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatus *g)
 	{
 		bson_t goalStatus;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &goalStatus);
@@ -36,7 +36,7 @@ public:
 		bson_append_document_end(b, &goalStatus);
 	}
 
-	static void _bson_append_goal_status(bson_t *b, ROSMessages::actionlib_msgs::GoalStatus *g)
+	static void _bson_append_goal_status(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatus *g)
 	{
 		UActionlibMsgsGoalIDConverter::_bson_append_child_goal_id(b, "goal_id", &(g->goal_id));
 		BSON_APPEND_INT32(b, "status", g->status);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.h
@@ -30,7 +30,7 @@ public:
 	}
 
 
-	static void _bson_append_child_point(bson_t *b, const char *key, ROSMessages::geometry_msgs::Point *p)
+	static void _bson_append_child_point(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Point *p)
 	{
 		bson_t point;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &point);
@@ -39,7 +39,7 @@ public:
 	}
 
 
-	static void _bson_append_point(bson_t *b, ROSMessages::geometry_msgs::Point *p)
+	static void _bson_append_point(bson_t *b, const ROSMessages::geometry_msgs::Point *p)
 	{
 		BSON_APPEND_DOUBLE(b, "x", p->x);
 		BSON_APPEND_DOUBLE(b, "y", p->y);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h
@@ -28,7 +28,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_pose(bson_t *b, const char *key, ROSMessages::geometry_msgs::Pose *t)
+	static void _bson_append_child_pose(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Pose *t)
 	{
 		bson_t pose;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &pose);
@@ -36,7 +36,7 @@ public:
 		bson_append_document_end(b, &pose);
 	}
 
-	static void _bson_append_pose(bson_t *b, ROSMessages::geometry_msgs::Pose *t)
+	static void _bson_append_pose(bson_t *b, const ROSMessages::geometry_msgs::Pose *t)
 	{
 		UGeometryMsgsPointConverter::_bson_append_child_point(b, "position", &(t->position));
 		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "orientation", &(t->orientation));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_pose_stamped(bson_t *b, const char *key, ROSMessages::geometry_msgs::PoseStamped * ps)
+	static void _bson_append_child_pose_stamped(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseStamped * ps)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
@@ -41,7 +41,7 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_pose_stamped(bson_t *b, ROSMessages::geometry_msgs::PoseStamped * ps)
+	static void _bson_append_pose_stamped(bson_t *b, const ROSMessages::geometry_msgs::PoseStamped * ps)
 	{
 		UStdMsgsHeaderConverter::_bson_append_header(b, &(ps->header));
 		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &(ps->pose));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
@@ -41,7 +41,7 @@ public:
 		bson_append_document_end(b, &pose);
 	}
 
-	static void _bson_append_pose_with_covariance(bson_t *b, ROSMessages::geometry_msgs::PoseWithCovariance *t)
+	static void _bson_append_pose_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::PoseWithCovariance *t)
 	{
 		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &(t->pose));
 		_bson_append_double_tarray(b, "covariance", t->covariance);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h
@@ -31,7 +31,7 @@ public:
 	}
 
 
-	static void _bson_append_child_quaternion(bson_t *b, const char *key, ROSMessages::geometry_msgs::Quaternion *q)
+	static void _bson_append_child_quaternion(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Quaternion *q)
 	{
 		bson_t quat;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &quat);
@@ -40,7 +40,7 @@ public:
 	}
 
 
-	static void _bson_append_quaternion(bson_t *b, ROSMessages::geometry_msgs::Quaternion *q)
+	static void _bson_append_quaternion(bson_t *b, const ROSMessages::geometry_msgs::Quaternion *q)
 	{
 		BSON_APPEND_DOUBLE(b, "x", q->x);
 		BSON_APPEND_DOUBLE(b, "y", q->y);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
@@ -28,7 +28,7 @@ public:
 		bson_append_document_end(b, &tform);
 	}
 
-	static void _bson_append_transform(bson_t *b, ROSMessages::geometry_msgs::Transform *t)
+	static void _bson_append_transform(bson_t *b, const ROSMessages::geometry_msgs::Transform *t)
 	{
 		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "translation", &(t->translation));
 		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "rotation", &(t->rotation));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
@@ -27,7 +27,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_twist(bson_t *b, const char *key, ROSMessages::geometry_msgs::Twist *t)
+	static void _bson_append_child_twist(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Twist *t)
 	{
 		bson_t twist;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &twist);
@@ -35,7 +35,7 @@ public:
 		bson_append_document_end(b, &twist);
 	}
 
-	static void _bson_append_twist(bson_t *b, ROSMessages::geometry_msgs::Twist *t)
+	static void _bson_append_twist(bson_t *b, const ROSMessages::geometry_msgs::Twist *t)
 	{
 		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "linear", &(t->linear));
 		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "angular", &(t->angular));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_twist_with_covariance(bson_t *b, const char *key, ROSMessages::geometry_msgs::TwistWithCovariance *t)
+	static void _bson_append_child_twist_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::TwistWithCovariance *t)
 	{
 		bson_t twist;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &twist);
@@ -41,7 +41,7 @@ public:
 		bson_append_document_end(b, &twist);
 	}
 
-	static void _bson_append_twist_with_covariance(bson_t *b, ROSMessages::geometry_msgs::TwistWithCovariance *t)
+	static void _bson_append_twist_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::TwistWithCovariance *t)
 	{
 		UGeometryMsgsTwistConverter::_bson_append_child_twist(b, "twist", &(t->twist));
 		_bson_append_double_tarray(b, "covariance", t->covariance);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h
@@ -28,7 +28,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_vector3(bson_t *b, const char *key, ROSMessages::geometry_msgs::Vector3 *v3)
+	static void _bson_append_child_vector3(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Vector3 *v3)
 	{
 		bson_t vec;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &vec);
@@ -37,7 +37,7 @@ public:
 	}
 
 
-	static void _bson_append_vector3(bson_t *b, ROSMessages::geometry_msgs::Vector3 *v3)
+	static void _bson_append_vector3(bson_t *b, const ROSMessages::geometry_msgs::Vector3 *v3)
 	{
 		BSON_APPEND_DOUBLE(b, "x", v3->x);
 		BSON_APPEND_DOUBLE(b, "y", v3->y);

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.h
@@ -50,7 +50,7 @@ public:
 		bson_append_document_end(b, &map);
 	}
 
-	static void _bson_append_grid_map(bson_t *b, ROSMessages::grid_map_msgs::GridMap *gm)
+	static void _bson_append_grid_map(bson_t *b, const ROSMessages::grid_map_msgs::GridMap *gm)
 	{
 		UGridMapMsgsGridMapInfoConverter::_bson_append_child_grid_map_info(b, "info", &gm->info);
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_grid_map_info(bson_t *b, const char *key, ROSMessages::grid_map_msgs::GridMapInfo *g)
+	static void _bson_append_child_grid_map_info(bson_t *b, const char *key, const ROSMessages::grid_map_msgs::GridMapInfo *g)
 	{
 		bson_t info;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &info);
@@ -41,7 +41,7 @@ public:
 		bson_append_document_end(b, &info);
 	}
 
-	static void _bson_append_grid_map_info(bson_t *b, ROSMessages::grid_map_msgs::GridMapInfo *g)
+	static void _bson_append_grid_map_info(bson_t *b, const ROSMessages::grid_map_msgs::GridMapInfo *g)
 	{
 		UStdMsgsHeaderConverter::_bson_append_header(b, &(g->header));
 		BSON_APPEND_DOUBLE(b, "resolution", g->resolution);

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
@@ -43,7 +43,7 @@ public:
 		bson_append_document_end(b, &mapmetadata);
 	}
 	
-	static void _bson_append_map_meta_data(bson_t *b, ROSMessages::nav_msgs::MapMetaData *mmd)
+	static void _bson_append_map_meta_data(bson_t *b, const ROSMessages::nav_msgs::MapMetaData *mmd)
 	{
 		bson_t map_load_time;
 		BSON_APPEND_DOCUMENT_BEGIN(b, "map_load_time", &map_load_time);

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.h
@@ -39,7 +39,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_laser_scan(bson_t *b, const char *key, ROSMessages::sensor_msgs::LaserScan *ls)
+	static void _bson_append_child_laser_scan(bson_t *b, const char *key, const ROSMessages::sensor_msgs::LaserScan *ls)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
@@ -47,7 +47,7 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_laser_scan(bson_t *b, ROSMessages::sensor_msgs::LaserScan *ls)
+	static void _bson_append_laser_scan(bson_t *b, const ROSMessages::sensor_msgs::LaserScan *ls)
 	{
 		UStdMsgsHeaderConverter::_bson_append_header(b, &ls->header);
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h
@@ -29,7 +29,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_float_multi_array(bson_t *b, const char *key, ROSMessages::std_msgs::Float32MultiArray *fma)
+	static void _bson_append_child_float_multi_array(bson_t *b, const char *key, const ROSMessages::std_msgs::Float32MultiArray *fma)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
@@ -37,7 +37,7 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_float_multi_array(bson_t *b, ROSMessages::std_msgs::Float32MultiArray *fma)
+	static void _bson_append_float_multi_array(bson_t *b, const ROSMessages::std_msgs::Float32MultiArray *fma)
 	{
 		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &fma->layout);
 		_bson_append_float_tarray(b, "data", fma->data);

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
@@ -33,7 +33,7 @@ public:
 	}
 
 	// Helper function to append a std_msgs/Header to a bson_t
-	static void _bson_append_header(bson_t *b, ROSMessages::std_msgs::Header *h)
+	static void _bson_append_header(bson_t *b, const ROSMessages::std_msgs::Header *h)
 	{
 		bson_t *hdr = BCON_NEW(
 			"seq", BCON_INT32(h->seq),

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h
@@ -28,7 +28,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_multi_array_dimension(bson_t *b, const char *key, ROSMessages::std_msgs::MultiArrayDimension *mad)
+	static void _bson_append_child_multi_array_dimension(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayDimension *mad)
 	{
 		bson_t m;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &m);
@@ -37,7 +37,7 @@ public:
 	}
 
 
-	static void _bson_append_multi_array_dimension(bson_t *b, ROSMessages::std_msgs::MultiArrayDimension *mad)
+	static void _bson_append_multi_array_dimension(bson_t *b, const ROSMessages::std_msgs::MultiArrayDimension *mad)
 	{
 		BSON_APPEND_UTF8(b, "label", TCHAR_TO_UTF8(*mad->label));
 		BSON_APPEND_INT32(b, "size", mad->size);

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h
@@ -36,7 +36,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_multi_array_layout(bson_t *b, const char *key, ROSMessages::std_msgs::MultiArrayLayout *mal)
+	static void _bson_append_child_multi_array_layout(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayLayout *mal)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
@@ -44,7 +44,7 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_multi_array_layout(bson_t *b, ROSMessages::std_msgs::MultiArrayLayout *mal)
+	static void _bson_append_multi_array_layout(bson_t *b, const ROSMessages::std_msgs::MultiArrayLayout *mal)
 	{
 		_bson_append_tarray<ROSMessages::std_msgs::MultiArrayDimension>(b, "dim", mal->dim, [](bson_t *subb, const char *subKey, ROSMessages::std_msgs::MultiArrayDimension mad)
 		{

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.h
@@ -29,7 +29,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_uint8_multi_array(bson_t *b, const char *key, ROSMessages::std_msgs::UInt8MultiArray *fma)
+	static void _bson_append_child_uint8_multi_array(bson_t *b, const char *key, const ROSMessages::std_msgs::UInt8MultiArray *fma)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
@@ -37,7 +37,7 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_uint8_multi_array(bson_t *b, ROSMessages::std_msgs::UInt8MultiArray *bma)
+	static void _bson_append_uint8_multi_array(bson_t *b, const ROSMessages::std_msgs::UInt8MultiArray *bma)
 	{
 		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &bma->layout);
 		bson_append_binary(b, "data", -1, BSON_SUBTYPE_BINARY, bma->data, bma->layout.dim[0].size);


### PR DESCRIPTION
I wanted to implement some new message, which contain arrays of existing messages, but because of the missing const modifier I was not allowed to.