### PR TITLE
Fix for TCP thread locking when ROS Connection is lost

### DIFF
--- a/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
@@ -156,7 +156,8 @@ int TCPConnection::ReceiverThreadFunction()
 						UE_LOG(LogROS, Error, TEXT("bytes_read is not 4 in bson_state_read_length==true. It's: %d"), bytes_read);
 					}
 				} else {
-					UE_LOG(LogROS, Error, TEXT("Failed to recv()"));
+					UE_LOG(LogROS, Error, TEXT("Failed to recv(); Closing receiver thread."));
+					run_receiver_thread = false;
 				}
 			} else {
 				// Message retrieval mode


### PR DESCRIPTION
### Bug

When the TCP connection to ROS is lost, the comm thread locks causing the Unreal Editor to subsequently lock-up.

### Fix 

Setting `run_receiver_thread` to `false` when this occurs allows the TCP connection to close and re-establish correctly when ROS communication is re-established.

The log statement is also updated to notify the thread will be closed.