### PR TITLE
Fix double tick clock advance.

### DIFF
--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -194,7 +194,7 @@ void UROSIntegrationGameInstance::BeginDestroy()
 
 void UROSIntegrationGameInstance::OnWorldTickStart(ELevelTick TickType, float DeltaTime)
 {
-	if (bSimulateTime)
+	if (bSimulateTime && TickType == ELevelTick::LEVELTICK_TimeOnly)
 	{
 		FApp::SetFixedDeltaTime(FixedUpdateInterval);
 		FApp::SetUseFixedTimeStep(bUseFixedUpdateInterval);


### PR DESCRIPTION
Only update simulation time if the UE tick is of time type. See issue #75 it goes into detail about the issues, read the last comment by me in which I detail what this fixes/does.