### PR TITLE
UE 4.24 OnWorldTickStart Definition Change

### DIFF
--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -48,7 +48,7 @@ public:
 protected:
 	void CheckROSBridgeHealth();
 
-	void OnWorldTickStart(ELevelTick TickType, float DeltaTime);
+	void OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime);
 
 	FTimerHandle TimerHandle_CheckHealth;
 	bool bTimerSet = false;  // has the time been set?

--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -3,6 +3,7 @@
 #include <CoreMinimal.h>
 #include <Engine/GameInstance.h>
 #include <Engine/EngineTypes.h>
+#include <Runtime/Launch/Resources/Version.h>
 #include "ROSIntegrationCore.h"
 
 #include "ROSIntegrationGameInstance.generated.h"
@@ -48,7 +49,11 @@ public:
 protected:
 	void CheckROSBridgeHealth();
 
+#if ENGINE_MINOR_VERSION > 23
 	void OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime);
+#else 
+	void OnWorldTickStart(ELevelTick TickType, float DeltaTime);
+#endif
 
 	FTimerHandle TimerHandle_CheckHealth;
 	bool bTimerSet = false;  // has the time been set?

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -192,7 +192,11 @@ void UROSIntegrationGameInstance::BeginDestroy()
 	UE_LOG(LogROS, Display, TEXT("ROS Game Instance - begin destroy - done"));
 }
 
+#if ENGINE_MINOR_VERSION > 23
 void UROSIntegrationGameInstance::OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime)
+#else 
+void UROSIntegrationGameInstance::OnWorldTickStart(ELevelTick TickType, float DeltaTime)
+#endif
 {
 	if (bSimulateTime && TickType == ELevelTick::LEVELTICK_TimeOnly)
 	{

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -192,7 +192,7 @@ void UROSIntegrationGameInstance::BeginDestroy()
 	UE_LOG(LogROS, Display, TEXT("ROS Game Instance - begin destroy - done"));
 }
 
-void UROSIntegrationGameInstance::OnWorldTickStart(ELevelTick TickType, float DeltaTime)
+void UROSIntegrationGameInstance::OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime)
 {
 	if (bSimulateTime && TickType == ELevelTick::LEVELTICK_TimeOnly)
 	{


### PR DESCRIPTION
### Summary

UE 4.24 appears to change the [FOnWorldTickStart](https://docs.unrealengine.com/en-US/API/Runtime/Engine/Engine/FWorldDelegates/FOnWorldTickStart/index.html) definition for [FWorldDelegates](https://docs.unrealengine.com/en-US/API/Runtime/Engine/Engine/FWorldDelegates/index.html) adding a pointer to `UWorld`.

~~This may break compatibility with versions prior to 4.24, but without it the plugin will not build for 
UE 4.24.~~

Please let me know your thoughts,

Tim

#### Update: 

`ENGINE_MINOR_VERSION` is now used to handle the `OnWorldTickStart` definition in order to support prior versions of UE4.