### PR TITLE
Fix crash when Topic & Message Type are unrecognized

### DIFF
--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -136,8 +136,12 @@ public:
 		UBaseMessageConverter** Converter = TypeConverterMap.Find(MessageType);
 		if (!Converter)
 		{
-			UE_LOG(LogROS, Error, TEXT("MessageType %s is unknown. Can't find Converter to decode message"), *MessageType);
-			check(false);
+      UE_LOG(LogROS,
+			       Error, 
+			       TEXT("MessageType [%s] for Topic [%s] "
+				    "is unknown. Message ignored."), 
+			       *MessageType, 
+			       *Topic);
 			return;
 		}
 		_Converter = *Converter;

--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -136,7 +136,7 @@ public:
 		UBaseMessageConverter** Converter = TypeConverterMap.Find(MessageType);
 		if (!Converter)
 		{
-      UE_LOG(LogROS,
+			UE_LOG(LogROS,
 			       Error, 
 			       TEXT("MessageType [%s] for Topic [%s] "
 				    "is unknown. Message ignored."), 


### PR DESCRIPTION
#### Summary

- Removes the check assertion call inside UTopics internal implementation 
- Updates UE_LOG error to make empty Topic names / Message types easier to read

