### PR TITLE
Installable Plugin

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -1,0 +1,9 @@
+[FilterPlugin]
+; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
+; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
+;
+; Examples:
+;    /README.txt
+;    /Extras/...
+;    /Binaries/ThirdParty/*.dll
+/ThirdParty/...

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ This plugin has been tested with Unreal Engine versions;
  ```
  
  * Link built plugin to `Plugins` directory of your project
- * Add to desired uproject (may be performed via Editor GUI as well).
+ * Add plugin to `build.cs`
+ ```
+		[Pulibc/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
+ ```
+ * Add to desired `uproject` (may be performed via Editor GUI as well).
  
  ```
  "Plugins": [

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ This plugin has been tested with Unreal Engine versions;
 
 ### Setting up the plugin
 
-#### Build with a project
-
  * Create a new C++ Unreal Project, or open your existing project. Please note that the Plugin might not get compiled automatically in BP-only Projects (see [this Issue](https://github.com/code-iai/ROSIntegration/issues/19)).
  * Add this repository to your `Plugins/` Folder in your Unreal project (copy the folder in so your structure looks like `MyUnrealProject/Plugins/ROSIntegration/ROSIntegration.uplugin`
  * Activate the Plugin in your UE4 project by opening your project and go to Edit -> Plugins. Search for ROSIntegration in the "other" section and activate it.
@@ -86,9 +84,9 @@ This plugin has been tested with Unreal Engine versions;
  * In some cases (for example on Linux), it might be necessary to call the Generate Project Files action on UE4 in order to fetch the new header files for the plugin. Reference: https://wiki.unrealengine.com/Generate_Visual_Studio_Project or https://wiki.unrealengine.com/Building_On_Linux#Generating_project_files_for_your_project
  
 
-#### Build standalone
+#### Build
 
-* Run the following 
+* Run the following: 
 
 ```
 [Run UAT script] BuildPlugin -Plugin="[FULL PATH]/ROSIntegration.uplugin" -TargetPlatform=[Platform] -Package="[Desired Location]" -Rocket
@@ -101,7 +99,7 @@ This plugin has been tested with Unreal Engine versions;
 ```
 [Public/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
 ```
-* Add plugin to `uproject` (may be performed via Editor GUI as well).
+* Add plugin to `uproject` (may be performed via Editor GUI as well)
 
 ```
 "Plugins": [

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This plugin has been tested with Unreal Engine versions;
 * Link to `Plugins` directory of your project
 * Add plugin to `build.cs`
 ```
-		[Pulibc/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
+[Public/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
 ```
 * Add plugin to `uproject` (may be performed via Editor GUI as well).
 

--- a/README.md
+++ b/README.md
@@ -62,28 +62,6 @@ This plugin has been tested with Unreal Engine versions;
 
 ### Setting up the plugin
 
-#### Build standalone
-
- ```
- [Run UAT script] BuildPlugin -Plugin="[FULL PATH]/ROSIntegration.uplugin" -TargetPlatform=[Platform] -Package="[Desired Location]" -Rocket
- ```
- 
- * Link built plugin to `Plugins` directory of your project
- * Add plugin to `build.cs`
- ```
-		[Pulibc/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
- ```
- * Add to desired `uproject` (may be performed via Editor GUI as well).
- 
- ```
- "Plugins": [
-     {
-       "Name": "ROSIntegration",
-       "Enabled": true
-     }
- ]
- ```
-
 #### Build with a project
 
  * Create a new C++ Unreal Project, or open your existing project. Please note that the Plugin might not get compiled automatically in BP-only Projects (see [this Issue](https://github.com/code-iai/ROSIntegration/issues/19)).
@@ -106,6 +84,33 @@ This plugin has been tested with Unreal Engine versions;
 
  * Don't forget to save everything (Ctrl + Shift + S)
  * In some cases (for example on Linux), it might be necessary to call the Generate Project Files action on UE4 in order to fetch the new header files for the plugin. Reference: https://wiki.unrealengine.com/Generate_Visual_Studio_Project or https://wiki.unrealengine.com/Building_On_Linux#Generating_project_files_for_your_project
+ 
+
+#### Build standalone
+
+* Run the following 
+
+```
+[Run UAT script] BuildPlugin -Plugin="[FULL PATH]/ROSIntegration.uplugin" -TargetPlatform=[Platform] -Package="[Desired Location]" -Rocket
+```
+
+ *UE may create a HostProject for the plugin, in which case, you'll find the plugin built inside HostProject/Plugins*
+
+* Link to `Plugins` directory of your project
+* Add plugin to `build.cs`
+```
+		[Pulibc/Private]DependencyModuleNames.AddRange(new string[] { "ROSIntegration" });
+```
+* Add plugin to `uproject` (may be performed via Editor GUI as well).
+
+```
+"Plugins": [
+    {
+      "Name": "ROSIntegration",
+      "Enabled": true
+    }
+]
+```
 
 ### C++ Topic Publish Example
 To get started, you can create a new C++ Actor and let it publish a message once at the BeginPlay Event.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ This plugin has been tested with Unreal Engine versions;
 
 ### Setting up the plugin
 
+#### Build standalone
+
+ ```
+ [Run UAT script] BuildPlugin -Plugin="[FULL PATH]/ROSIntegration.uplugin" -TargetPlatform=[Platform] -Package="[Desired Location]" -Rocket
+ ```
+ 
+ * Link built plugin to `Plugins` directory of your project
+ * Add to desired uproject (may be performed via Editor GUI as well).
+ 
+ ```
+ "Plugins": [
+     {
+       "Name": "ROSIntegration",
+       "Enabled": true
+     }
+ ]
+ ```
+
+#### Build with a project
+
  * Create a new C++ Unreal Project, or open your existing project. Please note that the Plugin might not get compiled automatically in BP-only Projects (see [this Issue](https://github.com/code-iai/ROSIntegration/issues/19)).
  * Add this repository to your `Plugins/` Folder in your Unreal project (copy the folder in so your structure looks like `MyUnrealProject/Plugins/ROSIntegration/ROSIntegration.uplugin`
  * Activate the Plugin in your UE4 project by opening your project and go to Edit -> Plugins. Search for ROSIntegration in the "other" section and activate it.

--- a/ROSIntegration.uplugin
+++ b/ROSIntegration.uplugin
@@ -10,9 +10,9 @@
 	"DocsURL": "https://github.com/code-iai/ROSIntegration",
 	"MarketplaceURL": "",
 	"SupportURL": "https://github.com/code-iai/ROSIntegration",
-	"CanContainContent": true,
+	"CanContainContent": false,
 	"IsBetaVersion": false,
-	"Installed": false,
+	"Installed": true,
 	"EnabledByDefault": true,
 	"Modules": [
 		{

--- a/Source/ROSIntegration/Classes/SpawnableObject.h
+++ b/Source/ROSIntegration/Classes/SpawnableObject.h
@@ -19,7 +19,7 @@ public:
 	ASpawnableObject(const FObjectInitializer& ObjectInitializer);
 
 	// A unique id that must be set by the caller
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category="SpawnableObject")
 	int32 Id;
 
 	UMaterialInstanceDynamic* TheMatInst;

--- a/Source/ROSIntegration/Classes/TFBroadcastComponent.h
+++ b/Source/ROSIntegration/Classes/TFBroadcastComponent.h
@@ -29,35 +29,35 @@ public:
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 	// Activate this Component by setting this flag to TRUE
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	bool ComponentActive;
 
 	// How often shall this frame be published (in Hz)?
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	uint32 FrameRate;
 
 	// Sets wether the coordinates of this actor shall be published in world coordinates or relative to the owning Actor
 	// If you set 'relative' here, please make sure that the actor of this component has a parent actor.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	ECoordinateType CoordsRelativeTo;
 
 	// Name of the Parentframe. This value will be set in the header of the ROS TF Message.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	FString ParentFrameName;
 
 	// Name of this Frame. This value will be set in the child_frame_id of the ROS TF Message.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	FString ThisFrameName;
 
 	// If ticked, TFComponent will check which Actors owns the Actor with this Component.
 	// It will then use the ActorLabel of the Parent as the ParentFrameName.
 	// When this mode is activated, the option 'CoordsRelativeTo' will be set to "Relative to Parent" and
 	// 'ParentFrameName' will be ignored.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	bool UseParentActorLabelAsParentFrame;
 
 	// If ticked, the ActorLabel of owning Actor will be used. 'ThisFrameName' will be ignored when used.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="TFBroadcastComponent")
 	bool UseActorLabelAsFrame;
 
 	float FrameTime, TimePassed;

--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
@@ -13,7 +13,7 @@
 #include <cstring>
 #include <functional>
 #include <bson.h>
-#include "Public/std_msgs/Header.h"
+#include "std_msgs/Header.h"
 
 #include "BaseMessageConverter.generated.h"
 

--- a/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
@@ -1,7 +1,12 @@
 #include "TCPConnection.h"
-#include <Networking.h>
-#include <iomanip>
+
 #include "ROSIntegrationCore.h"
+
+#include <iomanip>
+
+#include <Interfaces/IPv4/IPv4Address.h>
+#include <Serialization/ArrayReader.h>
+#include <SocketSubsystem.h>
 
 bool TCPConnection::Init(std::string ip_addr, int port)
 {

--- a/Source/ROSIntegration/Public/ROSIntegration.h
+++ b/Source/ROSIntegration/Public/ROSIntegration.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <CoreMinimal.h>
-#include <ModuleManager.h>
+#include <Modules/ModuleManager.h>
 
 class FROSIntegrationModule : public IModuleInterface
 {

--- a/Source/ROSIntegration/ROSIntegration.Build.cs
+++ b/Source/ROSIntegration/ROSIntegration.Build.cs
@@ -34,21 +34,10 @@ public class ROSIntegration : ModuleRules
 		Definitions.Add("RAPIDJSON_HAS_STDSTRING=1");
 #endif
 
-		PublicIncludePaths.AddRange(
-			new string[] {
-				// ... add public include paths required here ...
-			}
-		);
-
-
-		PrivateIncludePaths.AddRange(
-			new string[] {
-				"ROSIntegration/Private",
-				"ROSIntegration/Private/rosbridge2cpp"
-				// ... add other private include paths required here ...
-			}
-		);
-
+    PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+		
+		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
+    PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/rosbridge2cpp"));
 
 		PublicDependencyModuleNames.AddRange(
 			new string[]
@@ -66,8 +55,6 @@ public class ROSIntegration : ModuleRules
 			{
 				"CoreUObject",
 				"Engine",
-				"Slate",
-				"SlateCore",
 				"Sockets",
 				"Networking"
 				// ... add private dependencies that you statically link with here ...

--- a/Source/ROSIntegration/ROSIntegration.Build.cs
+++ b/Source/ROSIntegration/ROSIntegration.Build.cs
@@ -34,10 +34,10 @@ public class ROSIntegration : ModuleRules
 		Definitions.Add("RAPIDJSON_HAS_STDSTRING=1");
 #endif
 
-    PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+    		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
-    PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/rosbridge2cpp"));
+    		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/rosbridge2cpp"));
 
 		PublicDependencyModuleNames.AddRange(
 			new string[]


### PR DESCRIPTION
#### Summary 

This PR sets the Plugin to an 'Installed' plugin.

![image](https://user-images.githubusercontent.com/25569850/73910400-92c6a980-48f2-11ea-98f8-1a64c424ac9b.png)

##### Adds

- `Config/FilterPlugin.ini` for linking libbson binaries

##### Removes

- CanContainContent since this plugin does not have a Content directory
- Slate dependencies 

##### RunUAT Fixes 

The following were errors generated by the RunUAT tool when compiling the plugin by itself.

- Add missing category tags to uproperties
- Add `Public` directory to `PublicIncludePaths` and remove its usage inside `BaseMessageConverter`
- Fix `ModuleManager` include path
- Removes monolithic import of `Networking.h`

Readme updated with information regarding the installed plugin.

Note:  the plugin may still be used in the previous manner (setting Modules, AdditionalDependencies in the uproject) and UE will ask to rebuild it if it is not yet built by a project using it.
