### PR TITLE
Fix BSON Append Header Const Correctness

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
@@ -33,7 +33,7 @@ public:
 	}
 
 	// Helper function to append a std_msgs/Header to a bson_t
-	static void _bson_append_header(bson_t *b, ROSMessages::std_msgs::Header *h)
+	static void _bson_append_header(bson_t *b, const ROSMessages::std_msgs::Header *h)
 	{
 		bson_t *hdr = BCON_NEW(
 			"seq", BCON_INT32(h->seq),


### PR DESCRIPTION
##### Bug

A compiler error is generated when referencing `_bson_append_header`

```bash
[...]/ROSIntegration/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h:48:51: error: cannot initialize a parameter of type 'ROSMessages::std_msgs::Header *' with an rvalue of type 'const std_msgs::Header *'
```

##### Fix

Add `const` to header param in `_bson_append_header`