### PR TITLE
Fix Topic Advertise / Unadvertise Assertions

### DIFF
--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -84,15 +84,15 @@ public:
 
 	bool Advertise()
 	{
-		check(_ROSTopic);
-		return _ROSTopic->Advertise();
+		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to advertise null topic."))
+		return _ROSTopic && _ROSTopic->Advertise();
 	}
 
 
 	bool Unadvertise()
 	{
-		check(_ROSTopic);
-		return _ROSTopic->Unadvertise();
+		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to unadvertise null topic."))
+		return _ROSTopic && _ROSTopic->Unadvertise();
 	}
 
 

--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -84,14 +84,14 @@ public:
 
 	bool Advertise()
 	{
-		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to advertise null topic."))
+		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to advertise on an un-initialized topic."))
 		return _ROSTopic && _ROSTopic->Advertise();
 	}
 
 
 	bool Unadvertise()
 	{
-		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to unadvertise null topic."))
+		if (!_ROSTopic) UE_LOG(LogROS, Warning, TEXT("Trying to unadvertise on an un-initialized topic."))
 		return _ROSTopic && _ROSTopic->Unadvertise();
 	}
 


### PR DESCRIPTION
#### Bug

If someone calls `Unadvertise` / or `Advertise` before `Init` on a topic, the check assertion will cause the Editor / Game to crash.

#### Fix

Instead of using an assert, I recommend logging a warning to tell the user to initialize their topic first.