### PR TITLE
Feature/joint state msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ rosgraph_msgs/Clock                | ✓          | ✓
 sensor_msgs/CameraInfo             | ✘          | ✓
 sensor_msgs/Image                  | ✓          | ✓
 sensor_msgs/Imu                    | ✓          | ✓
+sensor_msgs/JointState             | ✓          | ✓
 sensor_msgs/NavSatFix              | ✓          | ✓
 sensor_msgs/NavSatStatus           | ✓          | ✓
 sensor_msgs/PointCloud2            | ✓          | ✓

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -7,8 +7,8 @@ USensorMsgsJointStateConverter::USensorMsgsJointStateConverter(const FObjectInit
 }
 
 bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg) {
-	ROSMessages::sensor_msgs::JointState* joint_state_msg = new ROSMessages::sensor_msgs::JointState;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg);
+	std::unique_ptr<ROSMessages::sensor_msgs::JointState> joint_state_msg = std::make_unique<ROSMessages::sensor_msgs::JointState>();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg.get());
 
 	const FString key = "msg";
 	bool KeyFound = false;

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -40,6 +40,7 @@ bool USensorMsgsJointStateConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseM
 	UStdMsgsHeaderConverter::_bson_append_header(*message, &(JointStateMessage->header));
 
 	// parent class utility methods
+	UBaseMessageConverter::_bson_append_tarray<FString>(*message, "name", JointStateMessage->name, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
 	UBaseMessageConverter::_bson_append_double_tarray(*message, "position", JointStateMessage->position);
 	UBaseMessageConverter::_bson_append_double_tarray(*message, "velocity", JointStateMessage->velocity);
 	UBaseMessageConverter::_bson_append_double_tarray(*message, "effort", JointStateMessage->effort);

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -10,7 +10,7 @@ bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePubli
 	ROSMessages::sensor_msgs::JointState* joint_state_msg = new ROSMessages::sensor_msgs::JointState;
 	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg);
 
-	constexpr FString key = "msg"
+	const FString key = "msg";
 	bool KeyFound = false;
 
 	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &joint_state_msg->header);

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -7,13 +7,14 @@ USensorMsgsJointStateConverter::USensorMsgsJointStateConverter(const FObjectInit
 }
 
 bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg) {
-	std::unique_ptr<ROSMessages::sensor_msgs::JointState> joint_state_msg = std::make_unique<ROSMessages::sensor_msgs::JointState>();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg.get());
+
+	auto joint_state_msg = new ROSMessages::sensor_msgs::JointState();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg);
 
 	const FString key = "msg";
 	bool KeyFound = false;
 
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &joint_state_msg->header);
+	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, key + ".header", &joint_state_msg->header);
 	if (!KeyFound) return false;
 
 	joint_state_msg->name = UBaseMessageConverter::GetTArrayFromBSON<FString>(key + ".name", message->full_msg_bson_, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
@@ -39,7 +40,7 @@ bool USensorMsgsJointStateConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseM
 	UStdMsgsHeaderConverter::_bson_append_header(*message, &(JointStateMessage->header));
 
 	// parent class utility methods
-	UBaseMessageConverter::_bson_append_double_tarray(*message, "position", JointStateMessage->position); 
+	UBaseMessageConverter::_bson_append_double_tarray(*message, "position", JointStateMessage->position);
 	UBaseMessageConverter::_bson_append_double_tarray(*message, "velocity", JointStateMessage->velocity);
 	UBaseMessageConverter::_bson_append_double_tarray(*message, "effort", JointStateMessage->effort);
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -1,0 +1,47 @@
+#include "Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h"
+
+USensorMsgsJointStateConverter::USensorMsgsJointStateConverter(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	_MessageType = "sensor_msgs/JointState";
+}
+
+bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg) {
+	ROSMessages::sensor_msgs::JointState* joint_state_msg = new ROSMessages::sensor_msgs::JointState;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg);
+
+	constexpr FString key = "msg"
+	bool KeyFound = false;
+
+	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &joint_state_msg->header);
+	if (!KeyFound) return false;
+
+	joint_state_msg->name = UBaseMessageConverter::GetTArrayFromBSON<FString>(key + ".name", message->full_msg_bson_, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
+	if (!KeyFound) return false;
+
+	joint_state_msg->position = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".position", message->full_msg_bson_, KeyFound);
+	if (!KeyFound) return false;
+
+	joint_state_msg->velocity = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".velocity", message->full_msg_bson_, KeyFound);
+	if (!KeyFound) return false;
+
+	joint_state_msg->effort = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".effort", message->full_msg_bson_, KeyFound);
+
+	return KeyFound;
+}
+
+bool USensorMsgsJointStateConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) {
+	auto JointStateMessage = StaticCastSharedPtr<ROSMessages::sensor_msgs::JointState>(BaseMsg);
+	
+	*message = new bson_t;
+	bson_init(*message);
+
+	UStdMsgsHeaderConverter::_bson_append_header(*message, &(JointStateMessage->header));
+
+	// parent class utility methods
+	UBaseMessageConverter::_bson_append_double_tarray(*message, "position", JointStateMessage->position); 
+	UBaseMessageConverter::_bson_append_double_tarray(*message, "velocity", JointStateMessage->velocity);
+	UBaseMessageConverter::_bson_append_double_tarray(*message, "effort", JointStateMessage->effort);
+
+	return true;
+}

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <UObject/ObjectMacros.h>
+#include <UObject/Object.h>
+#include "Conversion/Messages/BaseMessageConverter.h"
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "sensor_msgs/JointState.h"
+
+#include "SensorMsgsJointStateConverter.generated.h"
+
+
+UCLASS()
+class ROSINTEGRATION_API USensorMsgsJointStateConverter : public UBaseMessageConverter
+{
+	GENERATED_UCLASS_BODY()
+
+public:
+	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg);
+
+	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+};

--- a/Source/ROSIntegration/Public/sensor_msgs/JointState.h
+++ b/Source/ROSIntegration/Public/sensor_msgs/JointState.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "ROSBaseMsg.h"
+#include "std_msgs/Header.h"
+
+namespace ROSMessages {
+	namespace sensor_msgs {
+		class JointState : public FROSBaseMsg {
+		public:
+			JointState() {
+				_MessageType = "sensor_msgs/JointState";
+			}
+
+			/**# This is a message that holds data to describe the state of a set of torque controlled joints.
+			#
+			# The state of each joint(revolute or prismatic) is defined by :
+			#  * the position of the joint (rad or m),
+			#  * the velocity of the joint (rad/s or m/s) and
+			#  * the effort that is applied in the joint (Nm or N).
+			#
+			# Each joint is uniquely identified by its name
+			# The header specifies the time at which the joint states were recorded.All the joint states
+			# in one message have to be recorded at the same time.
+			#
+			# This message consists of a multiple arrays, one for each part of the joint state.
+			# The goal is to make each of the fields optional.When e.g.your joints have no
+			# effort associated with them, you can leave the effort array empty.
+			#
+			# All arrays in this message should have the same size, or be empty.
+			# This is the only way to uniquely associate the joint name with the correct
+			# states.
+			*/
+			ROSMessages::std_msgs::Header header;
+
+			TArray<Fstring> name;		// the joint name
+			TArray<double> position;	// the position of the joint (rad or m),
+			TArray<double> velocity;	// the velocity of the joint (rad/s or m/s)
+			TArray<double> effort;		// the effort that is applied in the joint (Nm or N)
+		};
+	}
+}

--- a/Source/ROSIntegration/Public/sensor_msgs/JointState.h
+++ b/Source/ROSIntegration/Public/sensor_msgs/JointState.h
@@ -11,7 +11,8 @@ namespace ROSMessages {
 				_MessageType = "sensor_msgs/JointState";
 			}
 
-			/**# This is a message that holds data to describe the state of a set of torque controlled joints.
+			/**
+			# This is a message that holds data to describe the state of a set of torque controlled joints.
 			#
 			# The state of each joint(revolute or prismatic) is defined by :
 			#  * the position of the joint (rad or m),

--- a/Source/ROSIntegration/Public/sensor_msgs/JointState.h
+++ b/Source/ROSIntegration/Public/sensor_msgs/JointState.h
@@ -32,7 +32,7 @@ namespace ROSMessages {
 			*/
 			ROSMessages::std_msgs::Header header;
 
-			TArray<Fstring> name;		// the joint name
+			TArray<FString> name;		// the joint name
 			TArray<double> position;	// the position of the joint (rad or m),
 			TArray<double> velocity;	// the velocity of the joint (rad/s or m/s)
 			TArray<double> effort;		// the effort that is applied in the joint (Nm or N)


### PR DESCRIPTION
This feature branch adds the `sensor_msgs/JointState` message to the list of supported messages. Tested with UE 4.21 under Windows 10 and ROS Kinetic Kame under Ubuntu 16. Tested publish and subscribe capabilities. Both were working well.

~~Please note that there is a memory leak in the implementation of the `ConvertIncomingMessage`. I kept the implementation as it is done with the other `ConvertIncomingMessage`. I believe the memory leak should be addressed separately in another PR. I am not familiar enough with the code base at this point to make those changes, but thought it would be useful for you to know about this problem.~~

The comment about memory leak was actually a false alarm. I believe this is ready to merge in its current state.