### PR TITLE
Add the ability to override and access clock related methods in ROSIntegrationGameInstance

### DIFF
--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -50,9 +50,9 @@ protected:
 	void CheckROSBridgeHealth();
 
 #if ENGINE_MINOR_VERSION > 23
-	void OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime);
+	virtual void OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime);
 #else 
-	void OnWorldTickStart(ELevelTick TickType, float DeltaTime);
+	virtual void OnWorldTickStart(ELevelTick TickType, float DeltaTime);
 #endif
 
 	FTimerHandle TimerHandle_CheckHealth;
@@ -61,8 +61,6 @@ protected:
 	bool bReconnect = false;
 
 	FCriticalSection initMutex_;
-
-private:
 
 	UPROPERTY()
 	class UTopic* ClockTopic = nullptr;


### PR DESCRIPTION
I had the need to make my own game instance and override the behavior of clock topic published by the `ROSIntegrationGameInstance.`

Changes:
- Added virtual to `OnWorldTickStart` to make it possible for children to override it
- Changed `ClockTopic` from private to protected to make it accessible by children

Results:
Tested on UE 4.25.3 and no behavior change is introduced. I created my own GameInstance which inherits the `ROSIntegrationGameInstance` and I was able to change the clock behavior (manually advance sim time when needed instead of sync with UE frame advance).