### PR TITLE
Cleaned up converters, added improvements, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The connection to the ROS world will be accomplished through http://wiki.ros.org
 
 UE 4.23 support has been recently added by Luigi Freda (see tested versions below)
 
-ROS2 support was recently added by [@tsender](https://github.com/tsender). Checkout the `ros2` branch for more details.
+**ROS2 support was recently added by [@tsender](https://github.com/tsender). Checkout the `ros2` branch for more details.**
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The connection to the ROS world will be accomplished through http://wiki.ros.org
 
 UE 4.23 support has been recently added by Luigi Freda (see tested versions below)
 
-**ROS2 support was recently added by [@tsender](https://github.com/tsender). Checkout the `ros2` branch for more details.**
-
 ## Description
 
 This Plugin contains the basic data structures to enable the user to communicate with a running roscore.

--- a/README.md
+++ b/README.md
@@ -38,16 +38,29 @@ It uses http://mongoc.org/libbson/ to encode and decode the whole ROS communicat
 Since BSON is not included in Unreal Engine (yet), its code has to be added to this plugin.
 Currently, this plugin comes with a pre-compiled libbson for Windows x64 and Linux x64 which doesn't need any additional configuration.
 
-To enable the communcation between Unreal and ROS, you will need a running ROSBridge (https://github.com/RobotWebTools/rosbridge_suite) with bson_mode. As an example for ROS kinetic, you can install it with:
+To enable the communcation between Unreal and ROS, you will need a running ROSBridge (https://github.com/RobotWebTools/rosbridge_suite) with bson_mode. Note: Please use rosbridge with version=>0.8.0 to get full BSON support.
+
+The recommended way to install rosbridge is from source (requires the `rosauth` package):
+```
+sudo apt-get install rosauth
+cd ~/ros_workspace/
+git clone -b ros1 https://github.com/RobotWebTools/rosbridge_suite.git
+cd ..
+catkin_make
+source devel/setup.bash
+```
+Even though you could install rosbridge using apt via:
 ```
 sudo apt-get install ros-kinetic-rosbridge-suite
 ```
-Note: Please use rosbridge with version=>0.8.0 to get full BSON support. After installing rosbridge, you can enable the bson_mode like this:
+if you were using ROS Kinetic, there have been numersous issues where these apt packages do not reflect the code in the `ros1` branch. Hence, it is best to install from source. After installing rosbridge, you can enable the bson_mode like this:
 
 ```
 roslaunch rosbridge_server rosbridge_tcp.launch bson_only_mode:=True
 ```
-**Important**: The most recent rosbridge versions changed the transmission method. Since ROSIntegration can not handle this new method yet, please make sure to check out these issue on how to install a compatible rosbridge version: https://github.com/code-iai/ROSIntegration/issues/141 & https://github.com/code-iai/ROSIntegration/issues/139
+If UE4 and rosbridge are both running, then you should see the rosbridge node subscribe to two topics beginning with `/unreal_ros/`. If you do NOT see this, then you likely have a problem with your rosbridge installation.
+
+<!-- **Important**: The most recent rosbridge versions changed the transmission method. Since ROSIntegration can not handle this new method yet, please make sure to check out these issue on how to install a compatible rosbridge version: https://github.com/code-iai/ROSIntegration/issues/141 & https://github.com/code-iai/ROSIntegration/issues/139 -->
 
 In our testing, we usually installed rosbridge on a Ubuntu Linux with ROS while the UE4 with ROSIntegration can be run on a Windows or Linux hosts. ROSBridge and UE4 with ROSIntegration don't need to be run on the same machine. So in order to run UE4 with ROSIntegration on Windows, you can either install a Linux Virtual Machine on your Windows Hosts or have a seperate, physical machine with Linux running in your network.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ geometry_msgs/Quaternion           | ✓          | ✓
 geometry_msgs/Transform            | ✓          | ✓
 geometry_msgs/TransformStamped     | ✓          | ✓
 geometry_msgs/Twist                | ✓          | ✓
+geometry_msgs/TwistStamped         | ✓          | ✓
 geometry_msgs/TwistWithCovariance  | ✓          | ✓
 geometry_msgs/Vector3              | ✓          | ✓
 grid_map_msgs/GridMap              | ✓          | ✓

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The connection to the ROS world will be accomplished through http://wiki.ros.org
 
 UE 4.23 support has been recently added by Luigi Freda (see tested versions below)
 
+ROS2 support was recently added by [@tsender](https://github.com/tsender). Checkout the `ros2` branch for more details.
+
 ## Description
 
 This Plugin contains the basic data structures to enable the user to communicate with a running roscore.
@@ -60,6 +62,8 @@ This plugin has previously been tested with Unreal Engine versions;
  * 4.20.3
  * **4.23** (by [Luigi Freda](http://www.luigifreda.com), fixed bugs with smart pointer management)
  * 4.24 
+ * 4.25
+ * 4.26
  
 Please note that this list is a tracker of which UE4 versions have been previously tested. It is not guaranteed that the most recent version of ROSIntegration is working with all previous UE4 versions.
 

--- a/Source/ROSIntegration/Classes/ROSBridgeParamOverride.h
+++ b/Source/ROSIntegration/Classes/ROSBridgeParamOverride.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "ROSBridgeParamOverride.generated.h"
+
+/**
+ * If you place this actor in the world, then you may override the parameters set in the ROSIntegrationGameInstance with the ones defined here.
+ * The purpose of this actor is to allow you to launch multiple UE editors on the same computer (each with a different level open) and use different rosbridge connection parameters in each level.
+ * This can be especially useful if you need to run independent parallel simulations on a single computer, each using a separate rosbridge node to distribute the load.
+ */
+UCLASS()
+class ROSINTEGRATION_API AROSBridgeParamOverride : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	AROSBridgeParamOverride()
+    {
+        PrimaryActorTick.bCanEverTick = false; // No need to tick
+    }
+
+    // IP address of the rosbridge websocket server
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
+	FString ROSBridgeServerHost = "127.0.0.1";
+
+	// Port number to access the rosbridge websocket server
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
+	int32 ROSBridgeServerPort = 9090;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
+	bool bConnectToROS = true;
+
+	UPROPERTY(EditAnywhere, Category = "ROS")
+	bool bSimulateTime = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ROS")
+	bool bUseFixedUpdateInterval = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ROS")
+	float FixedUpdateInterval = 0.01666666667;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ROS")
+	bool bCheckHealth = true;
+};

--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Messages/BaseMessageConverter.h"
 
 
-UBaseMessageConverter::UBaseMessageConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UBaseMessageConverter::UBaseMessageConverter()
 {
 }
 

--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
@@ -124,13 +124,11 @@ public:
 		return GetTArrayFromBSON<int32>(Key, msg, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetInt32FromBSON(subKey, subMsg, subKeyFound, false); }, LogOnErrors);
 	}
 
-	// Helper function to append a TArray<float> to a bson_t
-	static void _bson_append_float_tarray(bson_t *b, const char *key, const TArray<float>& tarray)
+	static TArray<bool> GetBoolTArrayFromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
 	{
-		// float -> double doesn't loose precision
-		_bson_append_double_tarray(b, key, (TArray<double>)tarray);
+		return GetTArrayFromBSON<bool>(Key, msg, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetBoolFromBSON(subKey, subMsg, subKeyFound, false); }, LogOnErrors);
 	}
-
+	
 	template<class T>
 	static void _bson_append_tarray(bson_t *b, const char *key, const TArray<T>& tarray, const std::function<void(bson_t*, const char*, const T&)>& appendT)
 	{
@@ -152,6 +150,13 @@ public:
 		_bson_append_tarray<double>(b, key, tarray, [](bson_t *subb, const char *subKey, double d) { BSON_APPEND_DOUBLE(subb, subKey, d); });
 	}
 
+	// Helper function to append a TArray<float> to a bson_t
+	static void _bson_append_float_tarray(bson_t *b, const char *key, const TArray<float>& tarray)
+	{
+		// float -> double doesn't loose precision
+		_bson_append_double_tarray(b, key, (TArray<double>)tarray);
+	}
+
 	// Helper function to append a TArray<uint8> to a bson_t
 	static void _bson_append_uint8_tarray(bson_t *b, const char *key, const TArray<uint8>& tarray)
 	{
@@ -169,5 +174,11 @@ public:
 	static void _bson_append_uint32_tarray(bson_t *b, const char *key, const TArray<uint32>& tarray)
 	{
 		_bson_append_tarray<uint32>(b, key, tarray, [](bson_t *subb, const char *subKey, uint32 i) { BSON_APPEND_INT32(subb, subKey, i); });
+	}
+	
+	// Helper function to append a TArray<bool> to a bson_t
+	static void _bson_append_bool_tarray(bson_t *b, const char *key, const TArray<bool>& tarray)
+	{
+		_bson_append_tarray<bool>(b, key, tarray, [](bson_t *subb, const char *subKey, bool i) { BSON_APPEND_BOOL(subb, subKey, i); });
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
@@ -1,28 +1,29 @@
 #pragma once
 
-#include <CoreMinimal.h>
+#include "CoreMinimal.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/WindowsHWrapper.h"
 #endif // PLATFORM_WINDOWS
 
 #include "ROSIntegrationCore.h"
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
 #include "rosbridge2cpp/messages/rosbridge_publish_msg.h"
 #include <cstring>
 #include <functional>
 #include <bson.h>
 #include "std_msgs/Header.h"
+#include "ROSTime.h"
 
 #include "BaseMessageConverter.generated.h"
 
 UCLASS()
 class ROSINTEGRATION_API UBaseMessageConverter: public UObject
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UBaseMessageConverter();
+	
 	UPROPERTY()
 	FString _MessageType;
 
@@ -64,13 +65,35 @@ public:
 		return value;
 	}
 
+	static int64 GetInt64FromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
+	{
+		assert(msg != nullptr);
+
+		int64 value = rosbridge2cpp::Helper::get_int64_by_key(TCHAR_TO_UTF8(*Key), *msg, KeyFound);
+		if (!KeyFound && LogOnErrors) {
+			UE_LOG(LogROS, Error, TEXT("Key %s not present in data"), *Key);
+		}
+		return value;
+	}
+
 	static bool GetBoolFromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
 	{
 		assert(msg != nullptr);
 
 		bool value = rosbridge2cpp::Helper::get_bool_by_key(TCHAR_TO_UTF8(*Key), *msg, KeyFound);
 		if (!KeyFound && LogOnErrors) {
-			UE_LOG(LogTemp, Error, TEXT("Key %s not present in data"), *Key);
+			UE_LOG(LogROS, Error, TEXT("Key %s not present in data"), *Key);
+		}
+		return value;
+	}
+
+	static const uint8* GetBinaryFromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
+	{
+		assert(msg != nullptr);
+		uint32_t binary_data_length = 0; // Gets populated by get_binary_by_key()
+		const uint8* value = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*Key), *msg, binary_data_length, KeyFound);
+		if (!KeyFound && LogOnErrors) {
+			UE_LOG(LogROS, Error, TEXT("Key %s not present in data"), *Key);
 		}
 		return value;
 	}
@@ -180,5 +203,22 @@ public:
 	static void _bson_append_bool_tarray(bson_t *b, const char *key, const TArray<bool>& tarray)
 	{
 		_bson_append_tarray<bool>(b, key, tarray, [](bson_t *subb, const char *subKey, bool i) { BSON_APPEND_BOOL(subb, subKey, i); });
+	}
+
+	static bool _bson_extract_child_ros_time(bson_t *b, FString key, FROSTime *time, bool LogOnErrors = true)
+	{
+		bool KeyFound = false;
+		time->_Sec = GetInt32FromBSON(key + ".secs", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		time->_NSec = GetInt32FromBSON(key + ".nsecs", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		return true;
+	}
+
+	static void _bson_append_child_ros_time(bson_t *b, const char* key, const FROSTime* time)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		BSON_APPEND_INT32(&child, "secs", time->_Sec);
+		BSON_APPEND_INT32(&child, "nsecs", time->_NSec);
+		bson_append_document_end(b, &child);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/BaseMessageConverter.h
@@ -124,8 +124,6 @@ public:
 		return GetTArrayFromBSON<int32>(Key, msg, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetInt32FromBSON(subKey, subMsg, subKeyFound, false); }, LogOnErrors);
 	}
 
-protected:
-
 	// Helper function to append a TArray<float> to a bson_t
 	static void _bson_append_float_tarray(bson_t *b, const char *key, const TArray<float>& tarray)
 	{

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h"
 
 
-UActionlibMsgsGoalIDConverter::UActionlibMsgsGoalIDConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+UActionlibMsgsGoalIDConverter::UActionlibMsgsGoalIDConverter()
 {
 	_MessageType = "actionlib_msgs/GoalID";
 }
 
 bool UActionlibMsgsGoalIDConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto g = new ROSMessages::actionlib_msgs::GoalID();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(g);
-	return _bson_extract_child_goal_id(message->full_msg_bson_, "msg", g);
+	auto msg = new ROSMessages::actionlib_msgs::GoalID();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_goal_id(message->full_msg_bson_, "msg", msg);
 }
 
 bool UActionlibMsgsGoalIDConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto GoalID = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalID>(BaseMsg);
-
+	auto CastMSG = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalID>(BaseMsg);
 	*message = bson_new();
-	_bson_append_goal_id(*message, GoalID.Get());
-
+	_bson_append_goal_id(*message, CastMSG.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/ObjectMacros.h"
-#include "UObject/Object.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "actionlib_msgs/GoalID.h"
 #include "ActionlibMsgsGoalIDConverter.generated.h"
@@ -11,38 +9,39 @@
 UCLASS()
 class ROSINTEGRATION_API UActionlibMsgsGoalIDConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UActionlibMsgsGoalIDConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_goal_id(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalID *g, bool LogOnErrors = true)
+	static bool _bson_extract_child_goal_id(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalID *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 		int32 Sec =   GetInt32FromBSON(key + ".stamp.secs", b, KeyFound, LogOnErrors);  if (!KeyFound) return false;
 		int32 NSec =  GetInt32FromBSON(key + ".stamp.nsecs", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		g->id = GetFStringFromBSON(key + ".id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		g->stamp = FROSTime(Sec, NSec);
+		msg->id = GetFStringFromBSON(key + ".id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->stamp = FROSTime(Sec, NSec);
 
 		return true;
 	}
 
-	static void _bson_append_child_goal_id(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalID *g)
+	static void _bson_append_child_goal_id(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalID *msg)
 	{
-		bson_t goalID;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &goalID);
-		_bson_append_goal_id(&goalID, g);
-		bson_append_document_end(b, &goalID);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_goal_id(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_goal_id(bson_t *b, const ROSMessages::actionlib_msgs::GoalID *g)
+	static void _bson_append_goal_id(bson_t *b, const ROSMessages::actionlib_msgs::GoalID *msg)
 	{
 		bson_t stamp;
 		BSON_APPEND_DOCUMENT_BEGIN(b, "stamp", &stamp);
-		BSON_APPEND_INT32(&stamp, "secs", g->stamp._Sec);
-		BSON_APPEND_INT32(&stamp, "nsecs", g->stamp._NSec);
+		BSON_APPEND_INT32(&stamp, "secs", msg->stamp._Sec);
+		BSON_APPEND_INT32(&stamp, "nsecs", msg->stamp._NSec);
 		bson_append_document_end(b, &stamp);
-		BSON_APPEND_UTF8(b, "id", TCHAR_TO_UTF8(*g->id));
+		BSON_APPEND_UTF8(b, "id", TCHAR_TO_UTF8(*msg->id));
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h"
 
 
-UActionlibMsgsGoalStatusArrayConverter::UActionlibMsgsGoalStatusArrayConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+UActionlibMsgsGoalStatusArrayConverter::UActionlibMsgsGoalStatusArrayConverter()
 {
 	_MessageType = "actionlib_msgs/GoalStatusArray";
 }
 
 bool UActionlibMsgsGoalStatusArrayConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto g = new ROSMessages::actionlib_msgs::GoalStatusArray();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(g);
-	return _bson_extract_child_goal_status_array(message->full_msg_bson_, "msg", g);
+	auto msg = new ROSMessages::actionlib_msgs::GoalStatusArray();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_goal_status_array(message->full_msg_bson_, "msg", msg);
 }
 
 bool UActionlibMsgsGoalStatusArrayConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto GoalStatusArray = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalStatusArray>(BaseMsg);
-
+	auto CastMSG = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalStatusArray>(BaseMsg);
 	*message = bson_new();
-	_bson_append_goal_status_array(*message, GoalStatusArray.Get());
-
+	_bson_append_goal_status_array(*message, CastMSG.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusArrayConverter.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/ObjectMacros.h"
-#include "UObject/Object.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h"
@@ -13,18 +11,19 @@
 UCLASS()
 class ROSINTEGRATION_API UActionlibMsgsGoalStatusArrayConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UActionlibMsgsGoalStatusArrayConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_goal_status_array(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalStatusArray *g, bool LogOnErrors = true)
+	static bool _bson_extract_child_goal_status_array(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalStatusArray *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &g->header); if (!KeyFound) return false;
-		g->status_list = GetTArrayFromBSON<ROSMessages::actionlib_msgs::GoalStatus>(key + ".status_list", b, KeyFound, [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound)
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->status_list = GetTArrayFromBSON<ROSMessages::actionlib_msgs::GoalStatus>(key + ".status_list", b, KeyFound, [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound)
 		{
 			ROSMessages::actionlib_msgs::GoalStatus ret;
 			subKeyFound = UActionlibMsgsGoalStatusConverter::_bson_extract_child_goal_status(subMsg, subKey, &ret, LogOnErrors);
@@ -35,18 +34,18 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_goal_status_array(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatusArray *g)
+	static void _bson_append_child_goal_status_array(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatusArray *msg)
 	{
-		bson_t array;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &array);
-		_bson_append_goal_status_array(&array, g);
-		bson_append_document_end(b, &array);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_goal_status_array(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_goal_status_array(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatusArray *g)
+	static void _bson_append_goal_status_array(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatusArray *msg)
 	{
-		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &(g->header));
-		_bson_append_tarray<ROSMessages::actionlib_msgs::GoalStatus>(b, "status_list", g->status_list, [](bson_t *subb, const char *subKey, ROSMessages::actionlib_msgs::GoalStatus gs)
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		_bson_append_tarray<ROSMessages::actionlib_msgs::GoalStatus>(b, "status_list", msg->status_list, [](bson_t *subb, const char *subKey, ROSMessages::actionlib_msgs::GoalStatus gs)
 		{
 			UActionlibMsgsGoalStatusConverter::_bson_append_child_goal_status(subb, subKey, &gs);
 		});

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h"
 
 
-UActionlibMsgsGoalStatusConverter::UActionlibMsgsGoalStatusConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+UActionlibMsgsGoalStatusConverter::UActionlibMsgsGoalStatusConverter()
 {
 	_MessageType = "actionlib_msgs/GoalStatus";
 }
 
 bool UActionlibMsgsGoalStatusConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto g = new ROSMessages::actionlib_msgs::GoalStatus();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(g);
-	return _bson_extract_child_goal_status(message->full_msg_bson_, "msg", g);
+	auto msg = new ROSMessages::actionlib_msgs::GoalStatus();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_goal_status(message->full_msg_bson_, "msg", msg);
 }
 
 bool UActionlibMsgsGoalStatusConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto GoalStatus = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalStatus>(BaseMsg);
-
+	auto CastMSG = StaticCastSharedPtr<ROSMessages::actionlib_msgs::GoalStatus>(BaseMsg);
 	*message = bson_new();
-	_bson_append_goal_status(*message, GoalStatus.Get());
-
+	_bson_append_goal_status(*message, CastMSG.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalStatusConverter.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/ObjectMacros.h"
-#include "UObject/Object.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/actionlib_msgs/ActionlibMsgsGoalIDConverter.h"
 #include "actionlib_msgs/GoalStatus.h"
@@ -12,34 +10,35 @@
 UCLASS()
 class ROSINTEGRATION_API UActionlibMsgsGoalStatusConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UActionlibMsgsGoalStatusConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_goal_status(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalStatus *g, bool LogOnErrors = true)
+	static bool _bson_extract_child_goal_status(bson_t *b, FString key, ROSMessages::actionlib_msgs::GoalStatus *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
-		KeyFound = UActionlibMsgsGoalIDConverter::_bson_extract_child_goal_id(b, key + ".goal_id", &g->goal_id, LogOnErrors); if (!KeyFound) return false;
-		g->status = static_cast<ROSMessages::actionlib_msgs::GoalStatus::Status>( GetInt32FromBSON(key + ".status", b, KeyFound, LogOnErrors) );  if (!KeyFound) return false; // TODO: there is no GetUInt8FromBSON, do we need to implement that?
-		g->text = GetFStringFromBSON(key + ".text", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		if (!UActionlibMsgsGoalIDConverter::_bson_extract_child_goal_id(b, key + ".goal_id", &msg->goal_id, LogOnErrors)) return false;
+		msg->status = static_cast<ROSMessages::actionlib_msgs::GoalStatus::Status>( GetInt32FromBSON(key + ".status", b, KeyFound, LogOnErrors) );  if (!KeyFound) return false; // TODO: there is no GetUInt8FromBSON, do we need to implement that?
+		msg->text = GetFStringFromBSON(key + ".text", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_goal_status(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatus *g)
+	static void _bson_append_child_goal_status(bson_t *b, const char *key, const ROSMessages::actionlib_msgs::GoalStatus *msg)
 	{
-		bson_t goalStatus;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &goalStatus);
-		_bson_append_goal_status(&goalStatus, g);
-		bson_append_document_end(b, &goalStatus);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_goal_status(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_goal_status(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatus *g)
+	static void _bson_append_goal_status(bson_t *b, const ROSMessages::actionlib_msgs::GoalStatus *msg)
 	{
-		UActionlibMsgsGoalIDConverter::_bson_append_child_goal_id(b, "goal_id", &(g->goal_id));
-		BSON_APPEND_INT32(b, "status", g->status);
-		BSON_APPEND_UTF8(b, "text", TCHAR_TO_UTF8(*g->text));
+		UActionlibMsgsGoalIDConverter::_bson_append_child_goal_id(b, "goal_id", &msg->goal_id);
+		BSON_APPEND_INT32(b, "status", msg->status);
+		BSON_APPEND_UTF8(b, "text", TCHAR_TO_UTF8(*msg->text));
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.cpp
@@ -2,25 +2,22 @@
 
 #include "geometry_msgs/Point.h"
 
-UGeometryMsgsPointConverter::UGeometryMsgsPointConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsPointConverter::UGeometryMsgsPointConverter()
 {
 	_MessageType = "geometry_msgs/Point";
 }
 
 bool UGeometryMsgsPointConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::Point();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_point(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::Point();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_point(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsPointConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Point = StaticCastSharedPtr<ROSMessages::geometry_msgs::Point>(BaseMsg);
-
+	auto CastMSG = StaticCastSharedPtr<ROSMessages::geometry_msgs::Point>(BaseMsg);
 	*message = bson_new();
-	_bson_append_point(*message, Point.Get());
-
+	_bson_append_point(*message, CastMSG.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.h
@@ -1,48 +1,46 @@
 #pragma once
 
 #include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "geometry_msgs/Point.h"
-
 #include "GeometryMsgsPointConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsPointConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsPointConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
 
-	static bool _bson_extract_child_point(bson_t *b, FString key, ROSMessages::geometry_msgs::Point *p, bool LogOnErrors = true)
+	static bool _bson_extract_child_point(bson_t *b, FString key, ROSMessages::geometry_msgs::Point *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		p->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		p->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		p->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 		return true;
 	}
 
 
-	static void _bson_append_child_point(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Point *p)
+	static void _bson_append_child_point(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Point *msg)
 	{
-		bson_t point;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &point);
-		_bson_append_point(&point, p);
-		bson_append_document_end(b, &point);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_point(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
 
-	static void _bson_append_point(bson_t *b, const ROSMessages::geometry_msgs::Point *p)
+	static void _bson_append_point(bson_t *b, const ROSMessages::geometry_msgs::Point *msg)
 	{
-		BSON_APPEND_DOUBLE(b, "x", p->x);
-		BSON_APPEND_DOUBLE(b, "y", p->y);
-		BSON_APPEND_DOUBLE(b, "z", p->z);
+		BSON_APPEND_DOUBLE(b, "x", msg->x);
+		BSON_APPEND_DOUBLE(b, "y", msg->y);
+		BSON_APPEND_DOUBLE(b, "z", msg->z);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
 
 
-UGeometryMsgsPoseConverter::UGeometryMsgsPoseConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsPoseConverter::UGeometryMsgsPoseConverter()
 {
 	_MessageType = "geometry_msgs/Pose";
 }
 
 bool UGeometryMsgsPoseConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::Pose();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_pose(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::Pose();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_pose(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsPoseConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Pose = StaticCastSharedPtr<ROSMessages::geometry_msgs::Pose>(BaseMsg);
-
+	auto CastMSG = StaticCastSharedPtr<ROSMessages::geometry_msgs::Pose>(BaseMsg);
 	*message = bson_new();
-	_bson_append_pose(*message, Pose.Get());
-
+	_bson_append_pose(*message, CastMSG.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h
@@ -1,44 +1,42 @@
 #pragma once
 
 #include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "geometry_msgs/Pose.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPointConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h"
-
+#include "geometry_msgs/Pose.h"
 #include "GeometryMsgsPoseConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsPoseConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsPoseConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_pose(bson_t *b, FString key, ROSMessages::geometry_msgs::Pose *p, bool LogOnErrors = true)
+	static bool _bson_extract_child_pose(bson_t *b, FString key, ROSMessages::geometry_msgs::Pose *msg, bool LogOnErrors = true)
 	{
-		if (!UGeometryMsgsPointConverter::_bson_extract_child_point(b, key + ".position", &p->position, LogOnErrors)) return false;
-		if (!UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(b, key + ".orientation", &p->orientation, LogOnErrors)) return false;
+		if (!UGeometryMsgsPointConverter::_bson_extract_child_point(b, key + ".position", &msg->position, LogOnErrors)) return false;
+		if (!UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(b, key + ".orientation", &msg->orientation, LogOnErrors)) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_pose(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Pose *t)
+	static void _bson_append_child_pose(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Pose *msg)
 	{
-		bson_t pose;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &pose);
-		_bson_append_pose(&pose, t);
-		bson_append_document_end(b, &pose);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_pose(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_pose(bson_t *b, const ROSMessages::geometry_msgs::Pose *t)
+	static void _bson_append_pose(bson_t *b, const ROSMessages::geometry_msgs::Pose *msg)
 	{
-		UGeometryMsgsPointConverter::_bson_append_child_point(b, "position", &(t->position));
-		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "orientation", &(t->orientation));
+		UGeometryMsgsPointConverter::_bson_append_child_point(b, "position", &msg->position);
+		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "orientation", &msg->orientation);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.cpp
@@ -1,29 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h"
 
 
-UGeometryMsgsPoseStampedConverter::UGeometryMsgsPoseStampedConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsPoseStampedConverter::UGeometryMsgsPoseStampedConverter()
 {
 	_MessageType = "geometry_msgs/PoseStamped";
 }
 
 bool UGeometryMsgsPoseStampedConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::PoseStamped();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-
-	if (!UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &p->header)) return false;
-	if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(message->full_msg_bson_, TEXT("msg.pose"), &p->pose)) return false;
-
-	return true;
+	auto msg = new ROSMessages::geometry_msgs::PoseStamped();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_pose_stamped(message->full_msg_bson_, "msg", msg);;
 }
 
 bool UGeometryMsgsPoseStampedConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto PoseStamped = StaticCastSharedPtr<ROSMessages::geometry_msgs::PoseStamped>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::PoseStamped>(BaseMsg);
 	*message = bson_new();
-	_bson_append_pose_stamped(*message, PoseStamped.Get());
-
+	_bson_append_pose_stamped(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h
@@ -1,49 +1,41 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
-
 #include "GeometryMsgsPoseStampedConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsPoseStampedConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsPoseStampedConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_pose_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::PoseStamped * ps, bool LogOnErrors = true)
+	static bool _bson_extract_child_pose_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::PoseStamped * msg, bool LogOnErrors = true)
 	{
-		bool KeyFound = false;
-
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &ps->header);
-		if (!KeyFound) return false;
-
-		KeyFound = UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".pose", &ps->pose);
-		if (!KeyFound) return false;
-
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".pose", &msg->pose)) return false;
 		return true;
 	}
 
-	static void _bson_append_child_pose_stamped(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseStamped * ps)
+	static void _bson_append_child_pose_stamped(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseStamped * msg)
 	{
-		bson_t layout;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
-		_bson_append_pose_stamped(&layout, ps);
-		bson_append_document_end(b, &layout);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_pose_stamped(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_pose_stamped(bson_t *b, const ROSMessages::geometry_msgs::PoseStamped * ps)
+	static void _bson_append_pose_stamped(bson_t *b, const ROSMessages::geometry_msgs::PoseStamped * msg)
 	{
-		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &(ps->header));
-		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &(ps->pose));
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &msg->pose);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.cpp
@@ -1,25 +1,22 @@
 #include "GeometryMsgsPoseWithCovarianceConverter.h"
 
 
-UGeometryMsgsPoseWithCovarianceConverter::UGeometryMsgsPoseWithCovarianceConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsPoseWithCovarianceConverter::UGeometryMsgsPoseWithCovarianceConverter()
 {
 	_MessageType = "geometry_msgs/PoseWithCovariance";
 }
 
 bool UGeometryMsgsPoseWithCovarianceConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::PoseWithCovariance();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_pose_with_covariance(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::PoseWithCovariance();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_pose_with_covariance(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsPoseWithCovarianceConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Pose = StaticCastSharedPtr<ROSMessages::geometry_msgs::PoseWithCovariance>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::PoseWithCovariance>(BaseMsg);
 	*message = bson_new();
-	_bson_append_pose_with_covariance(*message, Pose.Get());
-
+	_bson_append_pose_with_covariance(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
@@ -1,21 +1,19 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "geometry_msgs/PoseWithCovariance.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
-
+#include "geometry_msgs/PoseWithCovariance.h"
 #include "GeometryMsgsPoseWithCovarianceConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsPoseWithCovarianceConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsPoseWithCovarianceConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
@@ -27,23 +25,23 @@ public:
 			return false;
 
 		p->covariance = GetDoubleTArrayFromBSON(key + ".covariance", b, KeyFound, LogOnErrors);
-		if (!KeyFound || p->covariance.Num() != 36) // TODO: Magic Number?
+		if (!KeyFound || p->covariance.Num() != 36) // ROS requires there to be 36 elements
 			return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_pose_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseWithCovariance *t)
+	static void _bson_append_child_pose_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseWithCovariance *msg)
 	{
-		bson_t pose;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &pose);
-		_bson_append_pose_with_covariance(&pose, t);
-		bson_append_document_end(b, &pose);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_pose_with_covariance(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_pose_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::PoseWithCovariance *t)
+	static void _bson_append_pose_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::PoseWithCovariance *msg)
 	{
-		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &(t->pose));
-		_bson_append_double_tarray(b, "covariance", t->covariance);
+		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &msg->pose);
+		_bson_append_double_tarray(b, "covariance", msg->covariance);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_pose_with_covariance(bson_t *b, const char *key, ROSMessages::geometry_msgs::PoseWithCovariance *t)
+	static void _bson_append_child_pose_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::PoseWithCovariance *t)
 	{
 		bson_t pose;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &pose);

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h"
 
 
-UGeometryMsgsQuaternionConverter::UGeometryMsgsQuaternionConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsQuaternionConverter::UGeometryMsgsQuaternionConverter()
 {
 	_MessageType = "geometry_msgs/Quaternion";
 }
 
 bool UGeometryMsgsQuaternionConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::Quaternion();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_quaternion(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::Quaternion();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_quaternion(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsQuaternionConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Quaternion = StaticCastSharedPtr<ROSMessages::geometry_msgs::Quaternion>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::Quaternion>(BaseMsg);
 	*message = bson_new();
-	_bson_append_quaternion(*message, Quaternion.Get());
-
+	_bson_append_quaternion(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h
@@ -1,50 +1,45 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "geometry_msgs/Quaternion.h"
-
 #include "GeometryMsgsQuaternionConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsQuaternionConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsQuaternionConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-
-	static bool _bson_extract_child_quaternion(bson_t *b, FString key, ROSMessages::geometry_msgs::Quaternion *q, bool LogOnErrors = true)
+	static bool _bson_extract_child_quaternion(bson_t *b, FString key, ROSMessages::geometry_msgs::Quaternion *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		q->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		q->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		q->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		q->w = GetDoubleFromBSON(key + ".w", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->w = GetDoubleFromBSON(key + ".w", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 		return true;
 	}
 
-
-	static void _bson_append_child_quaternion(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Quaternion *q)
+	static void _bson_append_child_quaternion(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Quaternion *msg)
 	{
-		bson_t quat;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &quat);
-		_bson_append_quaternion(&quat, q);
-		bson_append_document_end(b, &quat);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_quaternion(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-
-	static void _bson_append_quaternion(bson_t *b, const ROSMessages::geometry_msgs::Quaternion *q)
+	static void _bson_append_quaternion(bson_t *b, const ROSMessages::geometry_msgs::Quaternion *msg)
 	{
-		BSON_APPEND_DOUBLE(b, "x", q->x);
-		BSON_APPEND_DOUBLE(b, "y", q->y);
-		BSON_APPEND_DOUBLE(b, "z", q->z);
-		BSON_APPEND_DOUBLE(b, "w", q->w);
+		BSON_APPEND_DOUBLE(b, "x", msg->x);
+		BSON_APPEND_DOUBLE(b, "y", msg->y);
+		BSON_APPEND_DOUBLE(b, "z", msg->z);
+		BSON_APPEND_DOUBLE(b, "w", msg->w);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.cpp
@@ -1,27 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h"
 
 
-UGeometryMsgsTransformConverter::UGeometryMsgsTransformConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsTransformConverter::UGeometryMsgsTransformConverter()
 {
 	_MessageType = "geometry_msgs/Transform";
 }
 
 bool UGeometryMsgsTransformConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-//    UE_LOG(LogTemp, Warning, TEXT("ROSIntegration: Transform receiving not implemented yet")); // TODO: use ROS log
-    UE_LOG(LogTemp, Warning, TEXT("ROSIntegration: Transform received"));
-    auto p = new ROSMessages::geometry_msgs::Transform;
-    BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-    return (_bson_extract_child_transform(message->full_msg_bson_, "msg", p));
+    auto msg = new ROSMessages::geometry_msgs::Transform;
+    BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+    return _bson_extract_child_transform(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsTransformConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Transform = StaticCastSharedPtr<ROSMessages::geometry_msgs::Transform>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::Transform>(BaseMsg);
 	*message = bson_new();
-	_bson_append_transform(*message, Transform.Get());
-
+	_bson_append_transform(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
@@ -27,7 +27,7 @@ public:
         return true;
     }
     
-    static void _bson_append_child_transform(bson_t *b, const char *key, ROSMessages::geometry_msgs::Transform *t)
+    static void _bson_append_child_transform(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Transform *t)
 	{
 		bson_t tform;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &tform);
@@ -35,7 +35,7 @@ public:
 		bson_append_document_end(b, &tform);
 	}
 
-	static void _bson_append_transform(bson_t *b, ROSMessages::geometry_msgs::Transform *t)
+	static void _bson_append_transform(bson_t *b, const ROSMessages::geometry_msgs::Transform *t)
 	{
 		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "translation", &(t->translation));
 		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "rotation", &(t->rotation));

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h
@@ -1,43 +1,41 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "geometry_msgs/Transform.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h"
-
 #include "GeometryMsgsTransformConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsTransformConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsTransformConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-    static bool _bson_extract_child_transform(bson_t *b, FString key, ROSMessages::geometry_msgs::Transform *p, bool LogOnErrors = true)
+    static bool _bson_extract_child_transform(bson_t *b, FString key, ROSMessages::geometry_msgs::Transform *msg, bool LogOnErrors = true)
     {
-        if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".translation", &(p->translation))) return false;
-        if (!UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(b, key + ".rotation", &(p->rotation))) return false;
+        if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".translation", &msg->translation)) return false;
+        if (!UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(b, key + ".rotation", &msg->rotation)) return false;
         return true;
     }
     
-    static void _bson_append_child_transform(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Transform *t)
+    static void _bson_append_child_transform(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Transform *msg)
 	{
-		bson_t tform;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &tform);
-		_bson_append_transform(b, t);
-		bson_append_document_end(b, &tform);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_transform(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_transform(bson_t *b, const ROSMessages::geometry_msgs::Transform *t)
+	static void _bson_append_transform(bson_t *b, const ROSMessages::geometry_msgs::Transform *msg)
 	{
-		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "translation", &(t->translation));
-		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "rotation", &(t->rotation));
+		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "translation", &msg->translation);
+		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "rotation", &msg->rotation);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.cpp
@@ -1,31 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.h"
 
-#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-#include "geometry_msgs/TransformStamped.h"
 
-
-UGeometryMsgsTransformStampedConverter::UGeometryMsgsTransformStampedConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsTransformStampedConverter::UGeometryMsgsTransformStampedConverter()
 {
 	_MessageType = "geometry_msgs/TransformStamped";
 }
 
 bool UGeometryMsgsTransformStampedConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-    UE_LOG(LogTemp, Warning, TEXT("ROSIntegration: TransformStamped received"));
-    auto p = new ROSMessages::geometry_msgs::TransformStamped;
-    BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-    return (_bson_extract_child_transform_stamped(message->full_msg_bson_, "msg", p));
+    auto msg = new ROSMessages::geometry_msgs::TransformStamped;
+    BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+    return _bson_extract_child_transform_stamped(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsTransformStampedConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto TransformStamped = StaticCastSharedPtr<ROSMessages::geometry_msgs::TransformStamped>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::TransformStamped>(BaseMsg);
 	*message = bson_new();
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(TransformStamped->header));
-	BSON_APPEND_UTF8(*message, "child_frame_id", TCHAR_TO_UTF8(*TransformStamped->child_frame_id));
-	UGeometryMsgsTransformConverter::_bson_append_child_transform(*message, "transform", &(TransformStamped->transform));
-
+	_bson_append_transform_stamped(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.h
@@ -1,31 +1,44 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
-#include "geometry_msgs/TransformStamped.h"
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTransformConverter.h"
-
+#include "geometry_msgs/TransformStamped.h"
 #include "GeometryMsgsTransformStampedConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsTransformStampedConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+    UGeometryMsgsTransformStampedConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-    static bool _bson_extract_child_transform_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::TransformStamped *p, bool LogOnErrors = true)
+    static bool _bson_extract_child_transform_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::TransformStamped *msg, bool LogOnErrors = true)
     {
         bool keyFound = false;
-        if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &(p->header), LogOnErrors)) return false;
-        p->child_frame_id = GetFStringFromBSON(key + ".child_frame_id", b, keyFound, LogOnErrors); if (!keyFound) return false;
-        if (!UGeometryMsgsTransformConverter::_bson_extract_child_transform(b, key + ".transform", &(p->transform), LogOnErrors)) return false;
+        if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header, LogOnErrors)) return false;
+        msg->child_frame_id = GetFStringFromBSON(key + ".child_frame_id", b, keyFound, LogOnErrors); if (!keyFound) return false;
+        if (!UGeometryMsgsTransformConverter::_bson_extract_child_transform(b, key + ".transform", &msg->transform, LogOnErrors)) return false;
         return true;
     }
+
+    static void _bson_append_child_transform_stamped(bson_t *b, const char *key, const ROSMessages::geometry_msgs::TransformStamped *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_transform_stamped(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_transform_stamped(bson_t *b, const ROSMessages::geometry_msgs::TransformStamped *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+        BSON_APPEND_UTF8(b, "child_frame_id", TCHAR_TO_UTF8(*msg->child_frame_id));
+        UGeometryMsgsTransformConverter::_bson_append_child_transform(b, "transform", &msg->transform);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h"
 
 
-UGeometryMsgsTwistConverter::UGeometryMsgsTwistConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsTwistConverter::UGeometryMsgsTwistConverter()
 {
 	_MessageType = "geometry_msgs/Twist";
 }
 
 bool UGeometryMsgsTwistConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::Twist();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_twist(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::Twist();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_twist(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsTwistConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Twist = StaticCastSharedPtr<ROSMessages::geometry_msgs::Twist>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::Twist>(BaseMsg);
 	*message = bson_new();
-	_bson_append_twist(*message, Twist.Get());
-
+	_bson_append_twist(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
@@ -1,43 +1,41 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "geometry_msgs/Twist.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h"
-
+#include "geometry_msgs/Twist.h"
 #include "GeometryMsgsTwistConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsTwistConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsTwistConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_twist(bson_t *b, FString key, ROSMessages::geometry_msgs::Twist *t, bool LogOnErrors = true)
+	static bool _bson_extract_child_twist(bson_t *b, FString key, ROSMessages::geometry_msgs::Twist *msg, bool LogOnErrors = true)
 	{
-		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".linear", &t->linear, LogOnErrors)) return false;
-		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".angular", &t->angular, LogOnErrors)) return false;
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".linear", &msg->linear, LogOnErrors)) return false;
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".angular", &msg->angular, LogOnErrors)) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_twist(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Twist *t)
+	static void _bson_append_child_twist(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Twist *msg)
 	{
-		bson_t twist;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &twist);
-		_bson_append_twist(&twist, t);
-		bson_append_document_end(b, &twist);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_twist(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_twist(bson_t *b, const ROSMessages::geometry_msgs::Twist *t)
+	static void _bson_append_twist(bson_t *b, const ROSMessages::geometry_msgs::Twist *msg)
 	{
-		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "linear", &(t->linear));
-		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "angular", &(t->angular));
+		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "linear", &msg->linear);
+		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "angular", &msg->angular);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h
@@ -19,10 +19,10 @@ public:
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_twist(bson_t *b, FString key, ROSMessages::geometry_msgs::Twist *p, bool LogOnErrors = true)
+	static bool _bson_extract_child_twist(bson_t *b, FString key, ROSMessages::geometry_msgs::Twist *t, bool LogOnErrors = true)
 	{
-		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".linear", &p->linear, LogOnErrors)) return false;
-		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".angular", &p->angular, LogOnErrors)) return false;
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".linear", &t->linear, LogOnErrors)) return false;
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".angular", &t->angular, LogOnErrors)) return false;
 
 		return true;
 	}

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h"
 
 
-UGeometryMsgsTwistStampedConverter::UGeometryMsgsTwistStampedConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsTwistStampedConverter::UGeometryMsgsTwistStampedConverter()
 {
 	_MessageType = "geometry_msgs/TwistStamped";
 }
 
 bool UGeometryMsgsTwistStampedConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::TwistStamped();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_twist_stamped(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::TwistStamped();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_twist_stamped(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsTwistStampedConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto TwistStamped = StaticCastSharedPtr<ROSMessages::geometry_msgs::TwistStamped>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::TwistStamped>(BaseMsg);
 	*message = bson_new();
-	_bson_append_twist_stamped(*message, TwistStamped.Get());
-
+	_bson_append_twist_stamped(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.cpp
@@ -1,0 +1,25 @@
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h"
+
+
+UGeometryMsgsTwistStampedConverter::UGeometryMsgsTwistStampedConverter(const FObjectInitializer& ObjectInitializer)
+: Super(ObjectInitializer)
+{
+	_MessageType = "geometry_msgs/TwistStamped";
+}
+
+bool UGeometryMsgsTwistStampedConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
+{
+	auto p = new ROSMessages::geometry_msgs::TwistStamped();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
+	return _bson_extract_child_twist_stamped(message->full_msg_bson_, "msg", p);
+}
+
+bool UGeometryMsgsTwistStampedConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
+{
+	auto TwistStamped = StaticCastSharedPtr<ROSMessages::geometry_msgs::TwistStamped>(BaseMsg);
+
+	*message = bson_new();
+	_bson_append_twist_stamped(*message, TwistStamped.Get());
+
+	return true;
+}

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <UObject/ObjectMacros.h>
+#include <UObject/Object.h>
+#include "Conversion/Messages/BaseMessageConverter.h"
+#include "geometry_msgs/TwistStamped.h"
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h"
+
+#include "GeometryMsgsTwistStampedConverter.generated.h"
+
+
+UCLASS()
+class ROSINTEGRATION_API UGeometryMsgsTwistStampedConverter : public UBaseMessageConverter
+{
+	GENERATED_UCLASS_BODY()
+
+public:
+	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
+	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_twist_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::TwistStamped *t, bool LogOnErrors = true)
+	{
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &t->header)) return false;
+		if (!UGeometryMsgsTwistConverter::_bson_extract_child_twist(b, key + ".twist", &t->twist, LogOnErrors)) return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_twist_stamped(bson_t *b, const char *key, const ROSMessages::geometry_msgs::TwistStamped *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_twist_stamped(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_twist_stamped(bson_t *b, const ROSMessages::geometry_msgs::TwistStamped *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		UGeometryMsgsTwistConverter::_bson_append_child_twist(b, "twist", &msg->twist);
+	}
+};

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistStampedConverter.h
@@ -1,29 +1,27 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "geometry_msgs/TwistStamped.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h"
-
+#include "geometry_msgs/TwistStamped.h"
 #include "GeometryMsgsTwistStampedConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsTwistStampedConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsTwistStampedConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_twist_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::TwistStamped *t, bool LogOnErrors = true)
+	static bool _bson_extract_child_twist_stamped(bson_t *b, FString key, ROSMessages::geometry_msgs::TwistStamped *msg, bool LogOnErrors = true)
 	{
-		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &t->header)) return false;
-		if (!UGeometryMsgsTwistConverter::_bson_extract_child_twist(b, key + ".twist", &t->twist, LogOnErrors)) return false;
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		if (!UGeometryMsgsTwistConverter::_bson_extract_child_twist(b, key + ".twist", &msg->twist, LogOnErrors)) return false;
 
 		return true;
 	}

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.cpp
@@ -1,25 +1,22 @@
 #include "GeometryMsgsTwistWithCovarianceConverter.h"
 
 
-UGeometryMsgsTwistWithCovarianceConverter::UGeometryMsgsTwistWithCovarianceConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsTwistWithCovarianceConverter::UGeometryMsgsTwistWithCovarianceConverter()
 {
 	_MessageType = "geometry_msgs/TwistWithCovariance";
 }
 
 bool UGeometryMsgsTwistWithCovarianceConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::TwistWithCovariance();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_twist_with_covariance(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::TwistWithCovariance();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_twist_with_covariance(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsTwistWithCovarianceConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Pose = StaticCastSharedPtr<ROSMessages::geometry_msgs::TwistWithCovariance>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::TwistWithCovariance>(BaseMsg);
 	*message = bson_new();
-	_bson_append_twist_with_covariance(*message, Pose.Get());
-
+	_bson_append_twist_with_covariance(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h
@@ -1,49 +1,47 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "geometry_msgs/TwistWithCovariance.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistConverter.h"
-
+#include "geometry_msgs/TwistWithCovariance.h"
 #include "GeometryMsgsTwistWithCovarianceConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsTwistWithCovarianceConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsTwistWithCovarianceConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_twist_with_covariance(bson_t *b, FString key, ROSMessages::geometry_msgs::TwistWithCovariance *p, bool LogOnErrors = true)
+	static bool _bson_extract_child_twist_with_covariance(bson_t *b, FString key, ROSMessages::geometry_msgs::TwistWithCovariance *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		if (!UGeometryMsgsTwistConverter::_bson_extract_child_twist(b, key + ".twist", &p->twist, LogOnErrors))
+		if (!UGeometryMsgsTwistConverter::_bson_extract_child_twist(b, key + ".twist", &msg->twist, LogOnErrors))
 			return false;
 
-		p->covariance = GetDoubleTArrayFromBSON(key + ".covariance", b, KeyFound, LogOnErrors);
-		if (!KeyFound || p->covariance.Num() != 36) // TODO: Magic Number?
+		msg->covariance = GetDoubleTArrayFromBSON(key + ".covariance", b, KeyFound, LogOnErrors);
+		if (!KeyFound || msg->covariance.Num() != 36) // ROS requires there to be 36 elements
 			return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_twist_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::TwistWithCovariance *t)
+	static void _bson_append_child_twist_with_covariance(bson_t *b, const char *key, const ROSMessages::geometry_msgs::TwistWithCovariance *msg)
 	{
-		bson_t twist;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &twist);
-		_bson_append_twist_with_covariance(&twist, t);
-		bson_append_document_end(b, &twist);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_twist_with_covariance(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_twist_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::TwistWithCovariance *t)
+	static void _bson_append_twist_with_covariance(bson_t *b, const ROSMessages::geometry_msgs::TwistWithCovariance *msg)
 	{
-		UGeometryMsgsTwistConverter::_bson_append_child_twist(b, "twist", &(t->twist));
-		_bson_append_double_tarray(b, "covariance", t->covariance);
+		UGeometryMsgsTwistConverter::_bson_append_child_twist(b, "twist", &msg->twist);
+		_bson_append_double_tarray(b, "covariance", msg->covariance);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.cpp
@@ -1,26 +1,21 @@
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h"
 
-#include "geometry_msgs/Vector3.h"
-
-UGeometryMsgsVector3Converter::UGeometryMsgsVector3Converter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGeometryMsgsVector3Converter::UGeometryMsgsVector3Converter()
 {
 	_MessageType = "geometry_msgs/Vector3";
 }
 
 bool UGeometryMsgsVector3Converter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::geometry_msgs::Vector3();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_vector3(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::geometry_msgs::Vector3();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_vector3(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGeometryMsgsVector3Converter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Vector3 = StaticCastSharedPtr<ROSMessages::geometry_msgs::Vector3>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::geometry_msgs::Vector3>(BaseMsg);
 	*message = bson_new();
-	_bson_append_vector3(*message, Vector3.Get());
-
+	_bson_append_vector3(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "geometry_msgs/Vector3.h"
 #include "GeometryMsgsVector3Converter.generated.h"
@@ -11,36 +9,35 @@
 UCLASS()
 class ROSINTEGRATION_API UGeometryMsgsVector3Converter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGeometryMsgsVector3Converter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-
-	static bool _bson_extract_child_vector3(bson_t *b, FString key, ROSMessages::geometry_msgs::Vector3 *p, bool LogOnErrors = true)
+	static bool _bson_extract_child_vector3(bson_t *b, FString key, ROSMessages::geometry_msgs::Vector3 *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
-
-		p->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		p->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		p->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->x = GetDoubleFromBSON(key + ".x", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->y = GetDoubleFromBSON(key + ".y", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->z = GetDoubleFromBSON(key + ".z", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 		return true;
 	}
 
-	static void _bson_append_child_vector3(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Vector3 *v3)
+	static void _bson_append_child_vector3(bson_t *b, const char *key, const ROSMessages::geometry_msgs::Vector3 *msg)
 	{
-		bson_t vec;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &vec);
-		_bson_append_vector3(&vec, v3);
-		bson_append_document_end(b, &vec);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_vector3(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
 
-	static void _bson_append_vector3(bson_t *b, const ROSMessages::geometry_msgs::Vector3 *v3)
+	static void _bson_append_vector3(bson_t *b, const ROSMessages::geometry_msgs::Vector3 *msg)
 	{
-		BSON_APPEND_DOUBLE(b, "x", v3->x);
-		BSON_APPEND_DOUBLE(b, "y", v3->y);
-		BSON_APPEND_DOUBLE(b, "z", v3->z);
+		BSON_APPEND_DOUBLE(b, "x", msg->x);
+		BSON_APPEND_DOUBLE(b, "y", msg->y);
+		BSON_APPEND_DOUBLE(b, "z", msg->z);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.cpp
@@ -1,24 +1,21 @@
 #include "GridMapMsgsGridMapConverter.h"
 
-UGridMapMsgsGridMapConverter::UGridMapMsgsGridMapConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGridMapMsgsGridMapConverter::UGridMapMsgsGridMapConverter()
 {
 	_MessageType = "grid_map_msgs/GridMap";
 }
 
 bool UGridMapMsgsGridMapConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::grid_map_msgs::GridMap;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_grid_map(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::grid_map_msgs::GridMap;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_grid_map(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGridMapMsgsGridMapConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto map = StaticCastSharedPtr<ROSMessages::grid_map_msgs::GridMap>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::grid_map_msgs::GridMap>(BaseMsg);
 	*message = bson_new();
-	_bson_append_grid_map(*message, map.Get());
-
+	_bson_append_grid_map(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapConverter.h
@@ -1,67 +1,65 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "grid_map_msgs/GridMap.h"
-#include "Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h"
-
+#include "Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h"
+#include "grid_map_msgs/GridMap.h"
 #include "GridMapMsgsGridMapConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGridMapMsgsGridMapConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGridMapMsgsGridMapConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_grid_map(bson_t *b, FString key, ROSMessages::grid_map_msgs::GridMap *gm)
+	static bool _bson_extract_child_grid_map(bson_t *b, FString key, ROSMessages::grid_map_msgs::GridMap *msg)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UGridMapMsgsGridMapInfoConverter::_bson_extract_child_grid_map_info(b, key + ".info", &gm->info); if (!KeyFound) return false;
+		if (!UGridMapMsgsGridMapInfoConverter::_bson_extract_child_grid_map_info(b, key + ".info", &msg->info)) return false;
 
-		gm->layers = GetTArrayFromBSON<FString>(key + ".layers", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
-		gm->basic_layers = GetTArrayFromBSON<FString>(key + ".basic_layers", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
+		msg->layers = GetTArrayFromBSON<FString>(key + ".layers", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
+		msg->basic_layers = GetTArrayFromBSON<FString>(key + ".basic_layers", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
 
-		gm->data = GetTArrayFromBSON<ROSMessages::std_msgs::Float32MultiArray>(key + ".data", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) {
+		msg->data = GetTArrayFromBSON<ROSMessages::std_msgs::Float32MultiArray>(key + ".data", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) {
 			ROSMessages::std_msgs::Float32MultiArray ret;
 			subKeyFound = UStdMsgsFloat32MultiArrayConverter::_bson_extract_child_float_multi_array(subMsg, subKey, &ret, false);
 			return ret;
 		});
 		if (!KeyFound) return false;
 
-		gm->outer_start_index = GetInt32FromBSON(key + ".outer_start_index", b, KeyFound); if (!KeyFound) return false;
-		gm->inner_start_index = GetInt32FromBSON(key + ".inner_start_index", b, KeyFound); if (!KeyFound) return false;
+		msg->outer_start_index = GetInt32FromBSON(key + ".outer_start_index", b, KeyFound); if (!KeyFound) return false;
+		msg->inner_start_index = GetInt32FromBSON(key + ".inner_start_index", b, KeyFound); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_grid_map(bson_t *b, const char *key, ROSMessages::grid_map_msgs::GridMap *gm)
+	static void _bson_append_child_grid_map(bson_t *b, const char *key, ROSMessages::grid_map_msgs::GridMap *msg)
 	{
-		bson_t map;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &map);
-		_bson_append_grid_map(&map, gm);
-		bson_append_document_end(b, &map);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_grid_map(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_grid_map(bson_t *b, const ROSMessages::grid_map_msgs::GridMap *gm)
+	static void _bson_append_grid_map(bson_t *b, const ROSMessages::grid_map_msgs::GridMap *msg)
 	{
-		UGridMapMsgsGridMapInfoConverter::_bson_append_child_grid_map_info(b, "info", &gm->info);
+		UGridMapMsgsGridMapInfoConverter::_bson_append_child_grid_map_info(b, "info", &msg->info);
 
-		_bson_append_tarray<FString>(b, "layers", gm->layers, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
-		_bson_append_tarray<FString>(b, "basic_layers", gm->basic_layers, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
+		_bson_append_tarray<FString>(b, "layers", msg->layers, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
+		_bson_append_tarray<FString>(b, "basic_layers", msg->basic_layers, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
 
-		_bson_append_tarray<ROSMessages::std_msgs::Float32MultiArray>(b, "data", gm->data, [](bson_t *subB, const char *subKey, ROSMessages::std_msgs::Float32MultiArray fma) {
+		_bson_append_tarray<ROSMessages::std_msgs::Float32MultiArray>(b, "data", msg->data, [](bson_t *subB, const char *subKey, ROSMessages::std_msgs::Float32MultiArray fma) {
 			UStdMsgsFloat32MultiArrayConverter::_bson_append_child_float_multi_array(subB, subKey, &fma);
 		});
 
-		BSON_APPEND_INT32(b, "outer_start_index", gm->outer_start_index);
-		BSON_APPEND_INT32(b, "inner_start_index", gm->inner_start_index);
+		BSON_APPEND_INT32(b, "outer_start_index", msg->outer_start_index);
+		BSON_APPEND_INT32(b, "inner_start_index", msg->inner_start_index);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.cpp
@@ -1,25 +1,22 @@
 #include "GridMapMsgsGridMapInfoConverter.h"
 
 
-UGridMapMsgsGridMapInfoConverter::UGridMapMsgsGridMapInfoConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UGridMapMsgsGridMapInfoConverter::UGridMapMsgsGridMapInfoConverter()
 {
 	_MessageType = "grid_map_msgs/GridMapInfo";
 }
 
 bool UGridMapMsgsGridMapInfoConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::grid_map_msgs::GridMapInfo;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_grid_map_info(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::grid_map_msgs::GridMapInfo;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_grid_map_info(message->full_msg_bson_, "msg", msg);
 }
 
 bool UGridMapMsgsGridMapInfoConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Info = StaticCastSharedPtr<ROSMessages::grid_map_msgs::GridMapInfo>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::grid_map_msgs::GridMapInfo>(BaseMsg);
 	*message = bson_new();
-	_bson_append_grid_map_info(*message, Info.Get());
-
+	_bson_append_grid_map_info(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/grid_map_msgs/GridMapMsgsGridMapInfoConverter.h
@@ -1,52 +1,50 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "grid_map_msgs/GridMapInfo.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
-
+#include "grid_map_msgs/GridMapInfo.h"
 #include "GridMapMsgsGridMapInfoConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UGridMapMsgsGridMapInfoConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UGridMapMsgsGridMapInfoConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_grid_map_info(bson_t *b, FString key, ROSMessages::grid_map_msgs::GridMapInfo *g)
+	static bool _bson_extract_child_grid_map_info(bson_t *b, FString key, ROSMessages::grid_map_msgs::GridMapInfo *msg)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &g->header); if (!KeyFound) return false;
-		g->resolution = GetDoubleFromBSON(key + ".resolution", b, KeyFound);							if (!KeyFound) return false;
-		g->length_x = GetDoubleFromBSON(key + ".length_x", b, KeyFound);								if (!KeyFound) return false;
-		g->length_y = GetDoubleFromBSON(key + ".length_y", b, KeyFound);								if (!KeyFound) return false;
-		KeyFound = UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".pose", &g->pose);	if (!KeyFound) return false;
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->resolution = GetDoubleFromBSON(key + ".resolution", b, KeyFound); if (!KeyFound) return false;
+		msg->length_x = GetDoubleFromBSON(key + ".length_x", b, KeyFound); if (!KeyFound) return false;
+		msg->length_y = GetDoubleFromBSON(key + ".length_y", b, KeyFound); if (!KeyFound) return false;
+		if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".pose", &msg->pose)) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_grid_map_info(bson_t *b, const char *key, const ROSMessages::grid_map_msgs::GridMapInfo *g)
+	static void _bson_append_child_grid_map_info(bson_t *b, const char *key, const ROSMessages::grid_map_msgs::GridMapInfo *msg)
 	{
-		bson_t info;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &info);
-		_bson_append_grid_map_info(&info, g);
-		bson_append_document_end(b, &info);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_grid_map_info(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_grid_map_info(bson_t *b, const ROSMessages::grid_map_msgs::GridMapInfo *g)
+	static void _bson_append_grid_map_info(bson_t *b, const ROSMessages::grid_map_msgs::GridMapInfo *msg)
 	{
-		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &(g->header));
-		BSON_APPEND_DOUBLE(b, "resolution", g->resolution);
-		BSON_APPEND_DOUBLE(b, "length_x", g->length_x);
-		BSON_APPEND_DOUBLE(b, "length_y", g->length_y);
-		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &(g->pose));
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_DOUBLE(b, "resolution", msg->resolution);
+		BSON_APPEND_DOUBLE(b, "length_x", msg->length_x);
+		BSON_APPEND_DOUBLE(b, "length_y", msg->length_y);
+		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "pose", &msg->pose);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.cpp
@@ -1,28 +1,22 @@
 #include "NavMsgsMapMetaDataConverter.h"
 
-#include "nav_msgs/MapMetaData.h"
-#include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
 
-
-UNavMsgsMapMetaDataConverter::UNavMsgsMapMetaDataConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UNavMsgsMapMetaDataConverter::UNavMsgsMapMetaDataConverter()
 {
 	_MessageType = "nav_msgs/MapMetaData";
 }
 
 bool UNavMsgsMapMetaDataConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::nav_msgs::MapMetaData;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_map_meta_data(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::nav_msgs::MapMetaData;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_map_meta_data(message->full_msg_bson_, "msg", msg);
 }
 
 bool UNavMsgsMapMetaDataConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto map = StaticCastSharedPtr<ROSMessages::nav_msgs::MapMetaData>(BaseMsg);
-	
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::nav_msgs::MapMetaData>(BaseMsg);
 	*message = bson_new();
-	_bson_append_map_meta_data(*message, map.Get());
-	
+	_bson_append_map_meta_data(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseConverter.h"
 #include "nav_msgs/MapMetaData.h"
 #include "NavMsgsMapMetaDataConverter.generated.h"
 
@@ -11,52 +10,48 @@
 UCLASS()
 class ROSINTEGRATION_API UNavMsgsMapMetaDataConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 	
 public:
+	UNavMsgsMapMetaDataConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 	
-	// Helper function to extract a child-std_msgs/Header from a bson_t
-	static bool _bson_extract_child_map_meta_data(bson_t *b, FString key, ROSMessages::nav_msgs::MapMetaData *mmd)
+	static bool _bson_extract_child_map_meta_data(bson_t *b, FString key, ROSMessages::nav_msgs::MapMetaData *msg)
 	{
 		bool KeyFound = false;
-		int32 Sec =  GetInt32FromBSON(key + ".map_load_time.secs",  b, KeyFound);  if (!KeyFound) return false;
-		int32 NSec = GetInt32FromBSON(key + ".map_load_time.nsecs", b, KeyFound); if (!KeyFound) return false;
-		mmd->map_load_time = FROSTime(Sec, NSec);
-		
-		mmd->resolution = (float)GetDoubleFromBSON(key + ".resolution", b, KeyFound);  if (!KeyFound) return false;
-		
-		mmd->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
-		mmd->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
-		
-		if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".origin", &mmd->origin)) return false;
+		// int32 Sec =  GetInt32FromBSON(key + ".map_load_time.secs",  b, KeyFound);  if (!KeyFound) return false;
+		// int32 NSec = GetInt32FromBSON(key + ".map_load_time.nsecs", b, KeyFound); if (!KeyFound) return false;
+		// msg->map_load_time = FROSTime(Sec, NSec);
+		if (!_bson_extract_child_ros_time(b, key + ".map_load_time", &msg->map_load_time)) return false;
+		msg->resolution = (float)GetDoubleFromBSON(key + ".resolution", b, KeyFound);  if (!KeyFound) return false;
+		msg->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
+		msg->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
+		if (!UGeometryMsgsPoseConverter::_bson_extract_child_pose(b, key + ".origin", &msg->origin)) return false;
 		
 		return true;
 	}
 	
-	static void _bson_append_child_map_meta_data(bson_t *b, const char *key, ROSMessages::nav_msgs::MapMetaData *mmd)
+	static void _bson_append_child_map_meta_data(bson_t *b, const char *key, const ROSMessages::nav_msgs::MapMetaData *msg)
 	{
-		bson_t mapmetadata;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &mapmetadata);
-		_bson_append_map_meta_data(&mapmetadata, mmd);
-		bson_append_document_end(b, &mapmetadata);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_map_meta_data(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 	
-	static void _bson_append_map_meta_data(bson_t *b, const ROSMessages::nav_msgs::MapMetaData *mmd)
+	static void _bson_append_map_meta_data(bson_t *b, const ROSMessages::nav_msgs::MapMetaData *msg)
 	{
-		bson_t map_load_time;
-		BSON_APPEND_DOCUMENT_BEGIN(b, "map_load_time", &map_load_time);
-		BSON_APPEND_INT32(&map_load_time, "secs",  mmd->map_load_time._Sec);
-		BSON_APPEND_INT32(&map_load_time, "nsecs", mmd->map_load_time._NSec);
-		bson_append_document_end(b, &map_load_time);
-		
-		BSON_APPEND_DOUBLE(b, "resolution", mmd->resolution);
-		
-		BSON_APPEND_INT32(b, "width",  mmd->width);
-		BSON_APPEND_INT32(b, "height", mmd->height);
-		
-		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "origin", &(mmd->origin));
+		// bson_t map_load_time;
+		// BSON_APPEND_DOCUMENT_BEGIN(b, "map_load_time", &map_load_time);
+		// BSON_APPEND_INT32(&map_load_time, "secs",  msg->map_load_time._Sec);
+		// BSON_APPEND_INT32(&map_load_time, "nsecs", msg->map_load_time._NSec);
+		// bson_append_document_end(b, &map_load_time);
+		_bson_append_child_ros_time(b, "map_load_time", &msg->map_load_time);
+		BSON_APPEND_DOUBLE(b, "resolution", msg->resolution);
+		BSON_APPEND_INT32(b, "width",  msg->width);
+		BSON_APPEND_INT32(b, "height", msg->height);
+		UGeometryMsgsPoseConverter::_bson_append_child_pose(b, "origin", &msg->origin);
 	}
 	
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.cpp
@@ -1,46 +1,22 @@
-#include "NavMsgsOccupancyGridConverter.h"
+#include "Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.h"
 
-#include "nav_msgs/OccupancyGrid.h"
-#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-#include "NavMsgsMapMetaDataConverter.h"
 
-UNavMsgsOccupancyGridConverter::UNavMsgsOccupancyGridConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UNavMsgsOccupancyGridConverter::UNavMsgsOccupancyGridConverter()
 {
 	_MessageType = "nav_msgs/OccupancyGrid";
 }
 
 bool UNavMsgsOccupancyGridConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto o = new ROSMessages::nav_msgs::OccupancyGrid();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(o);
-	
-	bool KeyFound = false;
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &o->header);
-	if (!KeyFound) return false;
-	
-	KeyFound = UNavMsgsMapMetaDataConverter::_bson_extract_child_map_meta_data(message->full_msg_bson_, TEXT("msg.info"), &o->info);
-	if (!KeyFound) return false;
-	
-	o->data = GetInt32TArrayFromBSON(TEXT("msg.data"), message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-	
-	return true;
+	auto msg = new ROSMessages::nav_msgs::OccupancyGrid();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_occupancy_grid(message->full_msg_bson_, "msg", msg);
 }
 
 bool UNavMsgsOccupancyGridConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto grid = StaticCastSharedPtr<ROSMessages::nav_msgs::OccupancyGrid>(BaseMsg);
-	
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::nav_msgs::OccupancyGrid>(BaseMsg);
 	*message = bson_new();
-	
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(grid->header));
-	
-	UNavMsgsMapMetaDataConverter::_bson_append_child_map_meta_data(*message, "info", &(grid->info));
-	
-	_bson_append_int32_tarray(*message, "data", grid->data);
-	
+	_bson_append_occupancy_grid(*message, CastMsg.Get());
 	return true;
 }
-
-

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOccupancyGridConverter.h
@@ -1,19 +1,46 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/nav_msgs/NavMsgsMapMetaDataConverter.h"
+#include "nav_msgs/OccupancyGrid.h"
 #include "NavMsgsOccupancyGridConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UNavMsgsOccupancyGridConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 	
 public:
+	UNavMsgsOccupancyGridConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_occupancy_grid(bson_t *b, FString key, ROSMessages::nav_msgs::OccupancyGrid *msg, bool LogOnErrors = true)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		if (!UNavMsgsMapMetaDataConverter::_bson_extract_child_map_meta_data(b, key + ".info", &msg->info)) return false;
+		msg->data = GetInt32TArrayFromBSON(key + ".data", b, KeyFound); if (!KeyFound) return false;
+		
+		return true;
+	}
+
+	static void _bson_append_child_occupancy_grid(bson_t *b, const char *key, const ROSMessages::nav_msgs::OccupancyGrid *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_occupancy_grid(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_occupancy_grid(bson_t *b, const ROSMessages::nav_msgs::OccupancyGrid *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		UNavMsgsMapMetaDataConverter::_bson_append_child_map_meta_data(b, "info", &msg->info);
+		_bson_append_int32_tarray(b, "data", msg->data);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.h"
 
 
-UNavMsgsOdometryConverter::UNavMsgsOdometryConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UNavMsgsOdometryConverter::UNavMsgsOdometryConverter()
 {
 	_MessageType = "nav_msgs/Odometry";
 }
@@ -17,7 +16,6 @@ bool UNavMsgsOdometryConverter::ConvertIncomingMessage(const ROSBridgePublishMsg
 bool UNavMsgsOdometryConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
 	auto CastMsg = StaticCastSharedPtr<ROSMessages::nav_msgs::Odometry>(BaseMsg);
-
 	*message = bson_new();
 	_bson_append_odometry(*message, CastMsg.Get());
 	return true;

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.h
@@ -1,37 +1,37 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h"
 #include "nav_msgs/Odometry.h"
-
 #include "NavMsgsOdometryConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UNavMsgsOdometryConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UNavMsgsOdometryConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
 	static bool _bson_extract_child_odometry(bson_t *b, FString key, ROSMessages::nav_msgs::Odometry * msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header); if (!KeyFound) return false;
+		
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
 		msg->child_frame_id = GetFStringFromBSON(key + ".child_frame_id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		KeyFound = UGeometryMsgsPoseWithCovarianceConverter::_bson_extract_child_pose_with_covariance(b, key + ".pose", &msg->pose); if (!KeyFound) return false;
-		KeyFound = UGeometryMsgsTwistWithCovarianceConverter::_bson_extract_child_twist_with_covariance(b, key + ".twist", &msg->twist); if (!KeyFound) return false;
+		if (!UGeometryMsgsPoseWithCovarianceConverter::_bson_extract_child_pose_with_covariance(b, key + ".pose", &msg->pose)) return false;
+		if (!UGeometryMsgsTwistWithCovarianceConverter::_bson_extract_child_twist_with_covariance(b, key + ".twist", &msg->twist)) return false;
+		
 		return true;
 	}
 
-	static void _bson_append_child_odometry(bson_t *b, const char *key, const ROSMessages::nav_msgs::Odometry * msg)
+	static void _bson_append_child_odometry(bson_t *b, const char *key, const ROSMessages::nav_msgs::Odometry *msg)
 	{
 		bson_t child;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
@@ -39,7 +39,7 @@ public:
 		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_odometry(bson_t *b, const ROSMessages::nav_msgs::Odometry * msg)
+	static void _bson_append_odometry(bson_t *b, const ROSMessages::nav_msgs::Odometry *msg)
 	{
 		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
 		BSON_APPEND_UTF8(b, "child_frame_id", TCHAR_TO_UTF8(*msg->child_frame_id));

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsOdometryConverter.h
@@ -4,6 +4,10 @@
 #include <UObject/ObjectMacros.h>
 #include <UObject/Object.h>
 #include "Conversion/Messages/BaseMessageConverter.h"
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseWithCovarianceConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsTwistWithCovarianceConverter.h"
+#include "nav_msgs/Odometry.h"
 
 #include "NavMsgsOdometryConverter.generated.h"
 
@@ -16,4 +20,30 @@ class ROSINTEGRATION_API UNavMsgsOdometryConverter : public UBaseMessageConverte
 public:
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_odometry(bson_t *b, FString key, ROSMessages::nav_msgs::Odometry * msg, bool LogOnErrors = true)
+	{
+		bool KeyFound = false;
+		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header); if (!KeyFound) return false;
+		msg->child_frame_id = GetFStringFromBSON(key + ".child_frame_id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		KeyFound = UGeometryMsgsPoseWithCovarianceConverter::_bson_extract_child_pose_with_covariance(b, key + ".pose", &msg->pose); if (!KeyFound) return false;
+		KeyFound = UGeometryMsgsTwistWithCovarianceConverter::_bson_extract_child_twist_with_covariance(b, key + ".twist", &msg->twist); if (!KeyFound) return false;
+		return true;
+	}
+
+	static void _bson_append_child_odometry(bson_t *b, const char *key, const ROSMessages::nav_msgs::Odometry * msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_odometry(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_odometry(bson_t *b, const ROSMessages::nav_msgs::Odometry * msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_UTF8(b, "child_frame_id", TCHAR_TO_UTF8(*msg->child_frame_id));
+		UGeometryMsgsPoseWithCovarianceConverter::_bson_append_child_pose_with_covariance(b, "pose", &msg->pose);
+		UGeometryMsgsTwistWithCovarianceConverter::_bson_append_child_twist_with_covariance(b, "twist", &msg->twist);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsPathConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/nav_msgs/NavMsgsPathConverter.h
@@ -1,30 +1,28 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsPoseStampedConverter.h"
 #include "nav_msgs/Path.h"
-
 #include "NavMsgsPathConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UNavMsgsPathConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UNavMsgsPathConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
 	static bool _bson_extract_child_path(bson_t *b, FString key, ROSMessages::nav_msgs::Path * path, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, TEXT("msg.header"), &path->header);
-		if (!KeyFound) return false;
+		
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &path->header)) return false;
 
 		path->poses = GetTArrayFromBSON<ROSMessages::geometry_msgs::PoseStamped>(key + ".poses", b, KeyFound, [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound)
 		{
@@ -37,18 +35,18 @@ public:
 		return true;
 	}
 
-	static void _bson_append_child_path(bson_t *b, const char *key, const ROSMessages::nav_msgs::Path * path)
+	static void _bson_append_child_path(bson_t *b, const char *key, const ROSMessages::nav_msgs::Path *msg)
 	{
 		bson_t child;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
-		_bson_append_path(&child, path);
+		_bson_append_path(&child, msg);
 		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_path(bson_t *b, const ROSMessages::nav_msgs::Path * path)
+	static void _bson_append_path(bson_t *b, const ROSMessages::nav_msgs::Path *msg)
 	{
-		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &(path->header));
-		_bson_append_tarray<ROSMessages::geometry_msgs::PoseStamped>(b, "poses", path->poses, [](bson_t* msg, const char* key, const ROSMessages::geometry_msgs::PoseStamped& pose_stamped)
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		_bson_append_tarray<ROSMessages::geometry_msgs::PoseStamped>(b, "poses", msg->poses, [](bson_t* msg, const char* key, const ROSMessages::geometry_msgs::PoseStamped& pose_stamped)
 		{
 			UGeometryMsgsPoseStampedConverter::_bson_append_child_pose_stamped(msg, key, &pose_stamped);
 		});

--- a/Source/ROSIntegration/Private/Conversion/Messages/rosgraph_msgs/ROSGraphMsgsClockConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/rosgraph_msgs/ROSGraphMsgsClockConverter.cpp
@@ -1,38 +1,22 @@
 #include "ROSGraphMsgsClockConverter.h"
 
-#include "rosgraph_msgs/Clock.h"
-#include "Conversion/Messages/BaseMessageConverter.h"
 
-UROSGraphMsgsClockConverter::UROSGraphMsgsClockConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UROSGraphMsgsClockConverter::UROSGraphMsgsClockConverter()
 {
 	_MessageType = "rosgraph_msgs/Clock";
 }
 
 bool UROSGraphMsgsClockConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto Clock = new ROSMessages::rosgraph_msgs::Clock();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(Clock);
-
-	bool KeyFound = false;
-
-	int32 Sec = GetInt32FromBSON("msg.clock.secs", message->full_msg_bson_, KeyFound);  if (!KeyFound) return false;
-	int32 NSec = GetInt32FromBSON("msg.clock.nsecs", message->full_msg_bson_, KeyFound); if (!KeyFound) return false;
-	Clock->_Clock = FROSTime(Sec, NSec);
-
-	return true;
+	auto msg = new ROSMessages::rosgraph_msgs::Clock();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_clock(message->full_msg_bson_, "msg", msg);
 }
 
 bool UROSGraphMsgsClockConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Clock = StaticCastSharedPtr<ROSMessages::rosgraph_msgs::Clock>(BaseMsg);
-
-	*message = BCON_NEW(
-		"clock", "{",
-		"secs", BCON_INT32(Clock->_Clock._Sec),
-		"nsecs", BCON_INT32(Clock->_Clock._NSec),
-		"}"
-	);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::rosgraph_msgs::Clock>(BaseMsg);
+	*message = bson_new();
+	_bson_append_clock(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/rosgraph_msgs/ROSGraphMsgsClockConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/rosgraph_msgs/ROSGraphMsgsClockConverter.h
@@ -1,19 +1,36 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "rosgraph_msgs/Clock.h"
 #include "ROSGraphMsgsClockConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UROSGraphMsgsClockConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UROSGraphMsgsClockConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_clock(bson_t *b, FString key, ROSMessages::rosgraph_msgs::Clock *msg, bool LogOnErrors = true)
+	{
+		return _bson_extract_child_ros_time(b, key + ".clock", &msg->_Clock, LogOnErrors);
+	}
+
+	static void _bson_append_child_clock(bson_t *b, const char *key, const ROSMessages::rosgraph_msgs::Clock *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_clock(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_clock(bson_t *b, const ROSMessages::rosgraph_msgs::Clock *msg)
+	{
+		_bson_append_child_ros_time(b, "clock", &msg->_Clock);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCameraInfoConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCameraInfoConverter.cpp
@@ -1,55 +1,28 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsCameraInfoConverter.h"
 
-#include "sensor_msgs/CameraInfo.h"
 
-
-USensorMsgsCameraInfoConverter::USensorMsgsCameraInfoConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+USensorMsgsCameraInfoConverter::USensorMsgsCameraInfoConverter()
 {
 	_MessageType = "sensor_msgs/CameraInfo";
 }
 
-bool USensorMsgsCameraInfoConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg) {
-	UE_LOG(LogROS, Warning, TEXT("ROSIntegration: CameraInfo receiving not implemented yet"));
-	return false;
+bool USensorMsgsCameraInfoConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg) 
+{
+	auto msg = new ROSMessages::sensor_msgs::CameraInfo;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_camera_info(message->full_msg_bson_, "msg", msg);
 }
 
-bool USensorMsgsCameraInfoConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) {
+bool USensorMsgsCameraInfoConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
+{
 
-	auto CameraInfo = StaticCastSharedPtr<ROSMessages::sensor_msgs::CameraInfo>(BaseMsg);
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::CameraInfo>(BaseMsg);
 
-	assert(CameraInfo->D.Num() >= 5); // TODO: use Unreal assertions
-	assert(CameraInfo->K.Num() >= 9);
-	assert(CameraInfo->R.Num() >= 9);
-	assert(CameraInfo->P.Num() >= 12);
+	// assert(CastMsg->K.Num() == 9); // TODO: use Unreal assertions
+	// assert(CastMsg->R.Num() == 9);
+	// assert(CastMsg->P.Num() == 12);
 
-	*message = BCON_NEW(
-		"header", "{",
-		"seq", BCON_INT32(CameraInfo->header.seq),
-		"stamp", "{",
-		"secs", BCON_INT32(CameraInfo->header.time._Sec),
-		"nsecs", BCON_INT32(CameraInfo->header.time._NSec),
-		"}",
-		"frame_id", BCON_UTF8(TCHAR_TO_UTF8(*CameraInfo->header.frame_id)),
-		"}",
-		"height", BCON_INT32(CameraInfo->height),
-		"width", BCON_INT32(CameraInfo->width),
-		"distortion_model", BCON_UTF8(TCHAR_TO_UTF8(*CameraInfo->distortion_model)),
-		"D", "[", BCON_DOUBLE(CameraInfo->D[0]), BCON_DOUBLE(CameraInfo->D[1]), BCON_DOUBLE(CameraInfo->D[2]), BCON_DOUBLE(CameraInfo->D[3]), BCON_DOUBLE(CameraInfo->D[4]), "]",
-		"K", "[", BCON_DOUBLE(CameraInfo->K[0]), BCON_DOUBLE(CameraInfo->K[1]), BCON_DOUBLE(CameraInfo->K[2]), BCON_DOUBLE(CameraInfo->K[3]), BCON_DOUBLE(CameraInfo->K[4]), BCON_DOUBLE(CameraInfo->K[5]), BCON_DOUBLE(CameraInfo->K[6]), BCON_DOUBLE(CameraInfo->K[7]), BCON_DOUBLE(CameraInfo->K[8]), "]",
-		"R", "[", BCON_DOUBLE(CameraInfo->R[0]), BCON_DOUBLE(CameraInfo->R[1]), BCON_DOUBLE(CameraInfo->R[2]), BCON_DOUBLE(CameraInfo->R[3]), BCON_DOUBLE(CameraInfo->R[4]), BCON_DOUBLE(CameraInfo->R[5]), BCON_DOUBLE(CameraInfo->R[6]), BCON_DOUBLE(CameraInfo->R[7]), BCON_DOUBLE(CameraInfo->R[8]), "]",
-		"P", "[", BCON_DOUBLE(CameraInfo->P[0]), BCON_DOUBLE(CameraInfo->P[1]), BCON_DOUBLE(CameraInfo->P[2]), BCON_DOUBLE(CameraInfo->P[3]), BCON_DOUBLE(CameraInfo->P[4]), BCON_DOUBLE(CameraInfo->P[5]), BCON_DOUBLE(CameraInfo->P[6]), BCON_DOUBLE(CameraInfo->P[7]), BCON_DOUBLE(CameraInfo->P[8]), BCON_DOUBLE(CameraInfo->P[9]), BCON_DOUBLE(CameraInfo->P[10]), BCON_DOUBLE(CameraInfo->P[11]), "]",
-		"binning_x", BCON_INT32(CameraInfo->binning_x),
-		"binning_y", BCON_INT32(CameraInfo->binning_y),
-		"roi",
-		"{",
-		"x_offset", BCON_INT32(CameraInfo->roi.x_offset),
-		"y_offset", BCON_INT32(CameraInfo->roi.y_offset),
-		"height", BCON_INT32(CameraInfo->roi.height),
-		"width", BCON_INT32(CameraInfo->roi.width),
-		"do_rectify", BCON_BOOL(CameraInfo->roi.do_rectify),
-		"}"
-	);
-
+	*message = bson_new();
+	_bson_append_camera_info(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCameraInfoConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCameraInfoConverter.h
@@ -1,19 +1,69 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.h"
+#include "sensor_msgs/CameraInfo.h"
 #include "SensorMsgsCameraInfoConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsCameraInfoConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsCameraInfoConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_camera_info(bson_t *b, FString key, ROSMessages::sensor_msgs::CameraInfo *msg)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
+		msg->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
+		msg->distortion_model = GetFStringFromBSON(key + ".distortion_model", b, KeyFound); if (!KeyFound) return false;
+
+		msg->D = GetDoubleTArrayFromBSON(key + "d", b, KeyFound); if (!KeyFound) return false;
+		msg->K = GetDoubleTArrayFromBSON(key + "k", b, KeyFound); if (!KeyFound || msg->K.Num() != 9) return false;
+		msg->R = GetDoubleTArrayFromBSON(key + "r", b, KeyFound); if (!KeyFound || msg->R.Num() != 9) return false;
+		msg->P = GetDoubleTArrayFromBSON(key + "p", b, KeyFound); if (!KeyFound || msg->P.Num() != 12) return false;
+		
+		msg->binning_x = GetInt32FromBSON(key + "binning_x", b, KeyFound); if (!KeyFound) return false;
+		msg->binning_y = GetInt32FromBSON(key + "binning_y", b, KeyFound); if (!KeyFound) return false;
+		if (!USensorMsgsRegionOfInterestConverter::_bson_extract_child_roi(b, key + ".roi", &msg->roi)) return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_camera_info(bson_t *b, const char *key, const ROSMessages::sensor_msgs::CameraInfo *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_camera_info(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_camera_info(bson_t *b, const ROSMessages::sensor_msgs::CameraInfo *msg)
+	{
+		// assert(CastMsg->D.Num() == 5); // TODO: use Unreal assertions
+		assert(CastMsg->K.Num() == 9); // TODO: use Unreal assertions
+		assert(CastMsg->R.Num() == 9);
+		assert(CastMsg->P.Num() == 12);
+		
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_INT32(b, "height", msg->height);
+		BSON_APPEND_INT32(b, "width", msg->width);
+		BSON_APPEND_UTF8(b, "distortion_model", TCHAR_TO_UTF8(*msg->distortion_model));
+		_bson_append_double_tarray(b, "d", msg->D);
+		_bson_append_double_tarray(b, "k", msg->K);
+		_bson_append_double_tarray(b, "r", msg->R);
+		_bson_append_double_tarray(b, "p", msg->P);	
+		BSON_APPEND_INT32(b, "binning_x", msg->binning_x);
+		BSON_APPEND_INT32(b, "binning_y", msg->binning_y);
+		USensorMsgsRegionOfInterestConverter::_bson_append_child_roi(b, "roi", &msg->roi);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCompressedImageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCompressedImageConverter.cpp
@@ -1,34 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsCompressedImageConverter.h"
 
 
-USensorMsgsCompressedImageConverter::USensorMsgsCompressedImageConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+USensorMsgsCompressedImageConverter::USensorMsgsCompressedImageConverter()
 {
 	_MessageType = "sensor_msgs/CompressedImage";
 }
 
 bool USensorMsgsCompressedImageConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::sensor_msgs::CompressedImage;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_image(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::sensor_msgs::CompressedImage;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_image(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsCompressedImageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Image = StaticCastSharedPtr<ROSMessages::sensor_msgs::CompressedImage>(BaseMsg);
-
-	*message = BCON_NEW(
-		"header", "{",
-		"seq", BCON_INT32(Image->header.seq),
-		"stamp", "{",
-		"secs", BCON_INT32(Image->header.time._Sec),
-		"nsecs", BCON_INT32(Image->header.time._NSec),
-		"}",
-		"frame_id", BCON_UTF8(TCHAR_TO_UTF8(*Image->header.frame_id)),
-		"}",
-		"format", BCON_UTF8(TCHAR_TO_UTF8(*Image->format))
-	);
-	bson_append_binary(*message, "data", -1, BSON_SUBTYPE_BINARY, Image->data, Image->data_size);
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::CompressedImage>(BaseMsg);
+	*message = bson_new();
+	_bson_append_image(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCompressedImageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsCompressedImageConverter.h
@@ -1,36 +1,45 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
-#include "sensor_msgs/CompressedImage.h"
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-
-
+#include "sensor_msgs/CompressedImage.h"
 #include "SensorMsgsCompressedImageConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsCompressedImageConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsCompressedImageConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_image(bson_t *b, FString key, ROSMessages::sensor_msgs::CompressedImage *img)
+	static bool _bson_extract_child_image(bson_t *b, FString key, ROSMessages::sensor_msgs::CompressedImage *msg)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, TEXT("msg.header"), &img->header); if (!KeyFound) return false;
-
-		img->format = GetFStringFromBSON(key + ".format", b, KeyFound); if (!KeyFound) return false;
-
-		uint32_t binSize = 0;
-		img->data = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*(key + ".data")), *b, binSize, KeyFound);
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->format = GetFStringFromBSON(key + ".format", b, KeyFound); if (!KeyFound) return false;
+		msg->data = GetBinaryFromBSON(key + ".data", b, KeyFound); if (!KeyFound) return false;
 
 		return KeyFound;
+	}
+
+	static void _bson_append_child_image(bson_t *b, const char *key, const ROSMessages::sensor_msgs::CompressedImage *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_image(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_image(bson_t *b, const ROSMessages::sensor_msgs::CompressedImage *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_UTF8(b, "format", TCHAR_TO_UTF8(*msg->format));
+		BSON_APPEND_BINARY(b, "data", BSON_SUBTYPE_BINARY, msg->data, msg->data_size);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.cpp
@@ -1,38 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.h"
 
 
-USensorMsgsImageConverter::USensorMsgsImageConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+USensorMsgsImageConverter::USensorMsgsImageConverter()
 {
 	_MessageType = "sensor_msgs/Image";
 }
 
 bool USensorMsgsImageConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::sensor_msgs::Image;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_image(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::sensor_msgs::Image;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_image(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsImageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Image = StaticCastSharedPtr<ROSMessages::sensor_msgs::Image>(BaseMsg);
-
-	*message = BCON_NEW(
-	"header", "{",
-	"seq", BCON_INT32(Image->header.seq),
-	"stamp", "{",
-	"secs", BCON_INT32(Image->header.time._Sec),
-	"nsecs", BCON_INT32(Image->header.time._NSec),
-	"}",
-	"frame_id", BCON_UTF8(TCHAR_TO_UTF8(*Image->header.frame_id)),
-	"}",
-	"height", BCON_INT32(Image->height),
-	"width", BCON_INT32(Image->width),
-	"is_bigendian", BCON_INT32(Image->is_bigendian),
-	"encoding", BCON_UTF8(TCHAR_TO_UTF8(*Image->encoding)),
-	"step", BCON_INT32(Image->step)
-	);
-	bson_append_binary(*message, "data", -1, BSON_SUBTYPE_BINARY, Image->data, Image->height * Image->step );
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::Image>(BaseMsg);
+	*message = bson_new();
+	_bson_append_image(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImageConverter.h
@@ -1,40 +1,53 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
-#include "sensor_msgs/Image.h"
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-
-
+#include "sensor_msgs/Image.h"
 #include "SensorMsgsImageConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsImageConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsImageConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_image(bson_t *b, FString key, ROSMessages::sensor_msgs::Image *img)
+	static bool _bson_extract_child_image(bson_t *b, FString key, ROSMessages::sensor_msgs::Image *msg)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, TEXT("msg.header"), &img->header); if (!KeyFound) return false;
-
-		img->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
-		img->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
-		img->encoding = GetFStringFromBSON(key + ".encoding", b, KeyFound); if (!KeyFound) return false;
-		img->is_bigendian = GetInt32FromBSON(key + ".is_bigendian", b, KeyFound); if (!KeyFound) return false;
-		img->step = GetInt32FromBSON(key + ".step", b, KeyFound); if (!KeyFound) return false;
-
-		uint32_t binSize = 0;
-		img->data = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*(key + ".data")), *b, binSize, KeyFound);
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
+		msg->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
+		msg->encoding = GetFStringFromBSON(key + ".encoding", b, KeyFound); if (!KeyFound) return false;
+		msg->is_bigendian = GetInt32FromBSON(key + ".is_bigendian", b, KeyFound); if (!KeyFound) return false;
+		msg->step = GetInt32FromBSON(key + ".step", b, KeyFound); if (!KeyFound) return false;
+		msg->data = GetBinaryFromBSON(key + ".data", b, KeyFound); if (!KeyFound) return false;
 
 		return KeyFound;
+	}
+
+	static void _bson_append_child_image(bson_t *b, const char *key, const ROSMessages::sensor_msgs::Image *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_image(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_image(bson_t *b, const ROSMessages::sensor_msgs::Image *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_INT32(b, "height", msg->height);
+		BSON_APPEND_INT32(b, "width", msg->width);
+		BSON_APPEND_UTF8(b, "encoding", TCHAR_TO_UTF8(*msg->encoding));
+		BSON_APPEND_INT32(b, "is_bigendian", msg->is_bigendian);
+		BSON_APPEND_INT32(b, "step", msg->step);
+		BSON_APPEND_BINARY(b, "data", BSON_SUBTYPE_BINARY, msg->data, msg->height * msg->step);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImuConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImuConverter.cpp
@@ -1,66 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsImuConverter.h"
 
-#include "sensor_msgs/Imu.h"
-#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-#include "Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h"
-#include "Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h"
 
-// http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html
-
-USensorMsgsImuConverter::USensorMsgsImuConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+USensorMsgsImuConverter::USensorMsgsImuConverter()
 {
 	_MessageType = "sensor_msgs/Imu";
 }
 
 bool USensorMsgsImuConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto i = new ROSMessages::sensor_msgs::Imu();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(i);
-
-	bool KeyFound = false;
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, TEXT("msg.header"), &i->header);
-	if (!KeyFound) return false;
-
-	KeyFound = UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(message->full_msg_bson_, TEXT("msg.orientation"), &i->orientation);
-	if (!KeyFound) return false;
-	
-	i->orientation_covariance = GetDoubleTArrayFromBSON("msg.orientation_covariance", message->full_msg_bson_, KeyFound);
-	if (!KeyFound || i->orientation_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
-		return false;
-	
-	KeyFound = UGeometryMsgsVector3Converter::_bson_extract_child_vector3(message->full_msg_bson_, "msg.angular_velocity",&i->angular_velocity);
-	if (!KeyFound) return false;
-
-	i->angular_velocity_covariance = GetDoubleTArrayFromBSON("msg.angular_velocity_covariance", message->full_msg_bson_, KeyFound);
-	if (!KeyFound || i->angular_velocity_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
-		return false;
-
-	KeyFound = UGeometryMsgsVector3Converter::_bson_extract_child_vector3(message->full_msg_bson_, "msg.linear_acceleration",&i->linear_acceleration);
-	if (!KeyFound) return false;
-
-	i->linear_acceleration_covariance = GetDoubleTArrayFromBSON("msg.linear_acceleration_covariance", message->full_msg_bson_, KeyFound);
-	if (!KeyFound || i->linear_acceleration_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
-		return false;
-		
-	return true;
+	auto msg = new ROSMessages::sensor_msgs::Imu();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_imu(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsImuConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Imu = StaticCastSharedPtr<ROSMessages::sensor_msgs::Imu>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::Imu>(BaseMsg);
 	*message = bson_new();
-
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(Imu->header));
-
-	UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(*message, "orientation", &(Imu->orientation));
-	_bson_append_double_tarray(*message, "orientation_covariance", Imu->orientation_covariance);
-	UGeometryMsgsVector3Converter::_bson_append_child_vector3(*message, "angular_velocity", &(Imu->angular_velocity));
-	_bson_append_double_tarray(*message, "angular_velocity_covariance", Imu->orientation_covariance);
-	UGeometryMsgsVector3Converter::_bson_append_child_vector3(*message, "linear_acceleration", &(Imu->linear_acceleration));
-	_bson_append_double_tarray(*message, "linear_acceleration_covariance", Imu->linear_acceleration_covariance);
-
+	_bson_append_imu(*message, CastMsg.Get());
 	return true;
 }
-

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImuConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsImuConverter.h
@@ -1,21 +1,66 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsQuaternionConverter.h"
+#include "Conversion/Messages/geometry_msgs/GeometryMsgsVector3Converter.h"
 #include "sensor_msgs/Imu.h"
-
 #include "SensorMsgsImuConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsImuConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsImuConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 	
+	static bool _bson_extract_child_imu(bson_t *b, FString key, ROSMessages::sensor_msgs::Imu *msg, bool LogOnErrors = true)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		if (!UGeometryMsgsQuaternionConverter::_bson_extract_child_quaternion(b, key + ".orientation", &msg->orientation)) return false;
+		
+		msg->orientation_covariance = GetDoubleTArrayFromBSON(key + ".orientation_covariance", b, KeyFound);
+		if (!KeyFound || msg->orientation_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
+			return false;
+		
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".angular_velocity", &msg->angular_velocity)) return false;
+
+		msg->angular_velocity_covariance = GetDoubleTArrayFromBSON(key + ".angular_velocity_covariance", b, KeyFound);
+		if (!KeyFound || msg->angular_velocity_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
+			return false;
+
+		if (!UGeometryMsgsVector3Converter::_bson_extract_child_vector3(b, key + ".linear_acceleration", &msg->linear_acceleration)) return false;
+
+		msg->linear_acceleration_covariance = GetDoubleTArrayFromBSON(key + ".linear_acceleration_covariance", b, KeyFound);
+		if (!KeyFound || msg->linear_acceleration_covariance.Num() != 9) // Size of covariance, 3x3 -> array of 9 see ROS IMU msg definition at above link
+			return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_imu(bson_t *b, const char *key, const ROSMessages::sensor_msgs::Imu *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_imu(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_imu(bson_t *b, const ROSMessages::sensor_msgs::Imu *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		UGeometryMsgsQuaternionConverter::_bson_append_child_quaternion(b, "orientation", &msg->orientation);
+		_bson_append_double_tarray(b, "orientation_covariance", msg->orientation_covariance);
+		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "angular_velocity", &msg->angular_velocity);
+		_bson_append_double_tarray(b, "angular_velocity_covariance", msg->orientation_covariance);
+		UGeometryMsgsVector3Converter::_bson_append_child_vector3(b, "linear_acceleration", &msg->linear_acceleration);
+		_bson_append_double_tarray(b, "linear_acceleration_covariance", msg->linear_acceleration_covariance);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.cpp
@@ -1,48 +1,23 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h"
 
-USensorMsgsJointStateConverter::USensorMsgsJointStateConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+
+USensorMsgsJointStateConverter::USensorMsgsJointStateConverter()
 {
 	_MessageType = "sensor_msgs/JointState";
 }
 
-bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg) {
+bool USensorMsgsJointStateConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg) 
+{
 
-	auto joint_state_msg = new ROSMessages::sensor_msgs::JointState();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(joint_state_msg);
-
-	const FString key = "msg";
-	bool KeyFound = false;
-
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, key + ".header", &joint_state_msg->header);
-	if (!KeyFound) return false;
-
-	joint_state_msg->name = UBaseMessageConverter::GetTArrayFromBSON<FString>(key + ".name", message->full_msg_bson_, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
-	if (!KeyFound) return false;
-
-	joint_state_msg->position = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".position", message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-
-	joint_state_msg->velocity = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".velocity", message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-
-	joint_state_msg->effort = UBaseMessageConverter::GetDoubleTArrayFromBSON(key + ".effort", message->full_msg_bson_, KeyFound);
-
-	return KeyFound;
+	auto msg = new ROSMessages::sensor_msgs::JointState();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_joint_state(message->full_msg_bson_, "msg", msg);
 }
 
-bool USensorMsgsJointStateConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) {
-	auto JointStateMessage = StaticCastSharedPtr<ROSMessages::sensor_msgs::JointState>(BaseMsg);
-	
+bool USensorMsgsJointStateConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
+{
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::JointState>(BaseMsg);
 	*message = bson_new();
-
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(JointStateMessage->header));
-
-	// parent class utility methods
-	UBaseMessageConverter::_bson_append_tarray<FString>(*message, "name", JointStateMessage->name, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
-	UBaseMessageConverter::_bson_append_double_tarray(*message, "position", JointStateMessage->position);
-	UBaseMessageConverter::_bson_append_double_tarray(*message, "velocity", JointStateMessage->velocity);
-	UBaseMessageConverter::_bson_append_double_tarray(*message, "effort", JointStateMessage->effort);
-
+	_bson_append_joint_state(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsJointStateConverter.h
@@ -1,23 +1,52 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 #include "sensor_msgs/JointState.h"
-
 #include "SensorMsgsJointStateConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsJointStateConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsJointStateConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg>& BaseMsg);
-
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
+	static bool _bson_extract_child_joint_state(bson_t *b, FString key, ROSMessages::sensor_msgs::JointState *msg, bool LogOnErrors = true)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+
+		msg->name = GetTArrayFromBSON<FString>(key + ".name", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetFStringFromBSON(subKey, subMsg, subKeyFound, false); });
+		if (!KeyFound) return false;
+
+		msg->position = GetDoubleTArrayFromBSON(key + ".position", b, KeyFound); if (!KeyFound) return false;
+		msg->velocity = GetDoubleTArrayFromBSON(key + ".velocity", b, KeyFound); if (!KeyFound) return false;
+		msg->effort = GetDoubleTArrayFromBSON(key + ".effort", b, KeyFound); if (!KeyFound) return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_joint_state(bson_t *b, const char *key, const ROSMessages::sensor_msgs::JointState *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_joint_state(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_joint_state(bson_t *b, const ROSMessages::sensor_msgs::JointState *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		_bson_append_tarray<FString>(b, "name", msg->name, [](bson_t *subb, const char *subKey, FString str) { BSON_APPEND_UTF8(subb, subKey, TCHAR_TO_UTF8(*str)); });
+		_bson_append_double_tarray(b, "position", msg->position);
+		_bson_append_double_tarray(b, "velocity", msg->velocity);
+		_bson_append_double_tarray(b, "effort", msg->effort);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.h"
 
-USensorMsgsLaserScanConverter::USensorMsgsLaserScanConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+
+USensorMsgsLaserScanConverter::USensorMsgsLaserScanConverter()
 {
 	_MessageType = "sensor_msgs/LaserScan";
 }
 
 bool USensorMsgsLaserScanConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::sensor_msgs::LaserScan;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_laser_scan(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::sensor_msgs::LaserScan;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_laser_scan(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsLaserScanConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto mad = StaticCastSharedPtr<ROSMessages::sensor_msgs::LaserScan>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::LaserScan>(BaseMsg);
 	*message = bson_new();
-	_bson_append_laser_scan(*message, mad.Get());
-
+	_bson_append_laser_scan(*message, CastMsg.Get());
 	return true;
 }
-

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsLaserScanConverter.h
@@ -1,65 +1,60 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include "sensor_msgs/LaserScan.h"
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-
+#include "sensor_msgs/LaserScan.h"
 #include "SensorMsgsLaserScanConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsLaserScanConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsLaserScanConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_laser_scan(bson_t *b, FString key, ROSMessages::sensor_msgs::LaserScan *ls, bool LogOnErrors = true)
+	static bool _bson_extract_child_laser_scan(bson_t *b, FString key, ROSMessages::sensor_msgs::LaserScan *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &ls->header); if (!KeyFound) return false;
+		KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header); if (!KeyFound) return false;
 
-		ls->angle_min		= (float)GetDoubleFromBSON(key + ".angle_min", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->angle_max		= (float)GetDoubleFromBSON(key + ".angle_max", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->angle_increment	= (float)GetDoubleFromBSON(key + ".angle_increment", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->time_increment	= (float)GetDoubleFromBSON(key + ".time_increment", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->scan_time		= (float)GetDoubleFromBSON(key + ".scan_time", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->range_min		= (float)GetDoubleFromBSON(key + ".range_min", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->range_max		= (float)GetDoubleFromBSON(key + ".range_max", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-
-		ls->ranges = GetFloatTArrayFromBSON(key + ".ranges", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		ls->intensities = GetFloatTArrayFromBSON(key + ".intensities", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->angle_min		= GetDoubleFromBSON(key + ".angle_min", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->angle_max		= GetDoubleFromBSON(key + ".angle_max", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->angle_increment = GetDoubleFromBSON(key + ".angle_increment", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->time_increment	= GetDoubleFromBSON(key + ".time_increment", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->scan_time		= GetDoubleFromBSON(key + ".scan_time", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->range_min		= GetDoubleFromBSON(key + ".range_min", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->range_max		= GetDoubleFromBSON(key + ".range_max", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->ranges = GetFloatTArrayFromBSON(key + ".ranges", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->intensities = GetFloatTArrayFromBSON(key + ".intensities", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_laser_scan(bson_t *b, const char *key, const ROSMessages::sensor_msgs::LaserScan *ls)
+	static void _bson_append_child_laser_scan(bson_t *b, const char *key, const ROSMessages::sensor_msgs::LaserScan *msg)
 	{
-		bson_t layout;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
-		_bson_append_laser_scan(&layout, ls);
-		bson_append_document_end(b, &layout);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_laser_scan(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_laser_scan(bson_t *b, const ROSMessages::sensor_msgs::LaserScan *ls)
+	static void _bson_append_laser_scan(bson_t *b, const ROSMessages::sensor_msgs::LaserScan *msg)
 	{
-		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &ls->header);
-
-		BSON_APPEND_DOUBLE(b, "angle_min", ls->angle_min);
-		BSON_APPEND_DOUBLE(b, "angle_max", ls->angle_max);
-		BSON_APPEND_DOUBLE(b, "angle_increment", ls->angle_increment);
-		BSON_APPEND_DOUBLE(b, "time_increment", ls->time_increment);
-		BSON_APPEND_DOUBLE(b, "scan_time", ls->scan_time);
-		BSON_APPEND_DOUBLE(b, "range_min", ls->range_min);
-		BSON_APPEND_DOUBLE(b, "range_max", ls->range_max);
-
-		_bson_append_float_tarray(b, "ranges", ls->ranges);
-		_bson_append_float_tarray(b, "intensities", ls->intensities);
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_DOUBLE(b, "angle_min", msg->angle_min);
+		BSON_APPEND_DOUBLE(b, "angle_max", msg->angle_max);
+		BSON_APPEND_DOUBLE(b, "angle_increment", msg->angle_increment);
+		BSON_APPEND_DOUBLE(b, "time_increment", msg->time_increment);
+		BSON_APPEND_DOUBLE(b, "scan_time", msg->scan_time);
+		BSON_APPEND_DOUBLE(b, "range_min", msg->range_min);
+		BSON_APPEND_DOUBLE(b, "range_max", msg->range_max);
+		_bson_append_float_tarray(b, "ranges", msg->ranges);
+		_bson_append_float_tarray(b, "intensities", msg->intensities);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatFixConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatFixConverter.cpp
@@ -1,59 +1,23 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsNavSatFixConverter.h"
 
-#include "sensor_msgs/NavSatFix.h"
-#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-#include "Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.h"
 
-USensorMsgsNavSatFixConverter::USensorMsgsNavSatFixConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+USensorMsgsNavSatFixConverter::USensorMsgsNavSatFixConverter()
 {
 	_MessageType = "sensor_msgs/NavSatFix";
 }
 
 bool USensorMsgsNavSatFixConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto nsf = new ROSMessages::sensor_msgs::NavSatFix();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(nsf);
-
-	bool KeyFound = false;
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(message->full_msg_bson_, "msg.header", &(nsf->header));
-	if (!KeyFound) return false;
-
-	KeyFound = USensorMsgsNavSatStatusConverter::_bson_extract_child_nav_sat_status(message->full_msg_bson_, "msg.status", &(nsf->status));
-	if (!KeyFound) return false;
-
-	nsf->latitude = GetDoubleFromBSON("msg.latitude", message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-
-	nsf->longitude = GetDoubleFromBSON("msg.longitude", message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-
-	nsf->altitude = GetDoubleFromBSON("msg.altitude", message->full_msg_bson_, KeyFound);
-	if (!KeyFound) return false;
-
-	nsf->position_covariance = GetDoubleTArrayFromBSON("msg.position_covariance", message->full_msg_bson_, KeyFound);
-	if (!KeyFound || nsf->position_covariance.Num() != 9) // Covariance is a 3x3 matrix, so we should have 9 elements.
-		return false;
-
-	nsf->position_covariance_type = static_cast<ROSMessages::sensor_msgs::NavSatFix::CovarianceType>(GetInt32FromBSON("msg.position_covariance_type", message->full_msg_bson_, KeyFound));
-	if (!KeyFound) return false;
-
-	return true;
+	auto msg = new ROSMessages::sensor_msgs::NavSatFix();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_nav_sat_fix(message->full_msg_bson_, "msg", msg);
+	
 }
 
 bool USensorMsgsNavSatFixConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto nsf = StaticCastSharedPtr<ROSMessages::sensor_msgs::NavSatFix>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::NavSatFix>(BaseMsg);
 	*message = bson_new();
-
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(nsf->header));
-	USensorMsgsNavSatStatusConverter::_bson_append_child_nav_sat_status(*message, "status", &(nsf->status));
-	BSON_APPEND_DOUBLE(*message, "latitude", nsf->latitude);
-	BSON_APPEND_DOUBLE(*message, "longitude", nsf->longitude);
-	BSON_APPEND_DOUBLE(*message, "altitude", nsf->altitude);
-	_bson_append_double_tarray(*message, "position_covariance", nsf->position_covariance);
-	BSON_APPEND_INT32(*message, "position_covariance_type", nsf->position_covariance_type);
-
+	_bson_append_nav_sat_fix(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatFixConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatFixConverter.h
@@ -1,18 +1,59 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.h"
+#include "sensor_msgs/NavSatFix.h"
 #include "SensorMsgsNavSatFixConverter.generated.h"
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsNavSatFixConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsNavSatFixConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_nav_sat_fix(bson_t *b, FString key, ROSMessages::sensor_msgs::NavSatFix *msg)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		if (!USensorMsgsNavSatStatusConverter::_bson_extract_child_nav_sat_status(b, key + ".status", &msg->status)) return false;
+
+		msg->latitude = GetDoubleFromBSON(key + ".latitude", b, KeyFound); if (!KeyFound) return false;
+		msg->longitude = GetDoubleFromBSON(key + ".longitude", b, KeyFound); if (!KeyFound) return false;
+		msg->altitude = GetDoubleFromBSON(key + ".altitude", b, KeyFound); if (!KeyFound) return false;
+
+		msg->position_covariance = GetDoubleTArrayFromBSON(key + ".position_covariance", b, KeyFound);
+		if (!KeyFound || msg->position_covariance.Num() != 9) // Covariance is a 3x3 matrix, so we should have 9 elements.
+			return false;
+
+		msg->position_covariance_type = static_cast<ROSMessages::sensor_msgs::NavSatFix::CovarianceType>(GetInt32FromBSON(key + ".position_covariance_type", b, KeyFound));
+		if (!KeyFound) return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_nav_sat_fix(bson_t *b, const char *key, const ROSMessages::sensor_msgs::NavSatFix *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_nav_sat_fix(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_nav_sat_fix(bson_t *b, const ROSMessages::sensor_msgs::NavSatFix *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		USensorMsgsNavSatStatusConverter::_bson_append_child_nav_sat_status(b, "status", &msg->status);
+		BSON_APPEND_DOUBLE(b, "latitude", msg->latitude);
+		BSON_APPEND_DOUBLE(b, "longitude", msg->longitude);
+		BSON_APPEND_DOUBLE(b, "altitude", msg->altitude);
+		_bson_append_double_tarray(b, "position_covariance", msg->position_covariance);
+		BSON_APPEND_INT32(b, "position_covariance_type", msg->position_covariance_type);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.cpp
@@ -1,24 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.h"
 
-USensorMsgsNavSatStatusConverter::USensorMsgsNavSatStatusConverter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+
+USensorMsgsNavSatStatusConverter::USensorMsgsNavSatStatusConverter()
 {
 	_MessageType = "sensor_msgs/NavSatStatus";
 }
 
 bool USensorMsgsNavSatStatusConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto nss = new ROSMessages::sensor_msgs::NavSatStatus();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(nss);
-	return _bson_extract_child_nav_sat_status(message->full_msg_bson_, "msg", nss);
+	auto msg = new ROSMessages::sensor_msgs::NavSatStatus();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_nav_sat_status(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsNavSatStatusConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto nss = StaticCastSharedPtr<ROSMessages::sensor_msgs::NavSatStatus>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::NavSatStatus>(BaseMsg);
 	*message = bson_new();
-	_bson_append_nav_sat_status(*message, nss.Get());
-
+	_bson_append_nav_sat_status(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsNavSatStatusConverter.h
@@ -1,46 +1,44 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
-#include "sensor_msgs/NavSatStatus.h"
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "sensor_msgs/NavSatStatus.h"
 #include "SensorMsgsNavSatStatusConverter.generated.h"
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsNavSatStatusConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsNavSatStatusConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_nav_sat_status(bson_t* b, FString key, ROSMessages::sensor_msgs::NavSatStatus* nss, bool LogOnErrors = true)
+	static bool _bson_extract_child_nav_sat_status(bson_t* b, FString key, ROSMessages::sensor_msgs::NavSatStatus* msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		nss->status = static_cast<ROSMessages::sensor_msgs::NavSatStatus::Status>(GetInt32FromBSON(key + ".status", b, KeyFound, LogOnErrors));
+		msg->status = static_cast<ROSMessages::sensor_msgs::NavSatStatus::Status>(GetInt32FromBSON(key + ".status", b, KeyFound, LogOnErrors));
 		if (!KeyFound) return false;
 
-		nss->service = static_cast<ROSMessages::sensor_msgs::NavSatStatus::Service>(GetInt32FromBSON(key + ".service", b, KeyFound, LogOnErrors));
+		msg->service = static_cast<ROSMessages::sensor_msgs::NavSatStatus::Service>(GetInt32FromBSON(key + ".service", b, KeyFound, LogOnErrors));
 		if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_nav_sat_status(bson_t* b, const char *key, ROSMessages::sensor_msgs::NavSatStatus* nss)
+	static void _bson_append_child_nav_sat_status(bson_t* b, const char *key, const ROSMessages::sensor_msgs::NavSatStatus* msg)
 	{
-		bson_t result;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &result);
-		_bson_append_nav_sat_status(&result, nss);
-		bson_append_document_end(b, &result);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_nav_sat_status(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_nav_sat_status(bson_t* b, ROSMessages::sensor_msgs::NavSatStatus* nss)
+	static void _bson_append_nav_sat_status(bson_t* b, const ROSMessages::sensor_msgs::NavSatStatus* msg)
 	{
-		BSON_APPEND_INT32(b, "status", nss->status);
-		BSON_APPEND_INT32(b, "service", nss->service);
+		BSON_APPEND_INT32(b, "status", msg->status);
+		BSON_APPEND_INT32(b, "service", msg->service);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsPointCloud2Converter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsPointCloud2Converter.cpp
@@ -1,77 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsPointCloud2Converter.h"
-#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
-
-#include "sensor_msgs/PointCloud2.h"
 
 
-USensorMsgsPointCloud2Converter::USensorMsgsPointCloud2Converter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+USensorMsgsPointCloud2Converter::USensorMsgsPointCloud2Converter()
 {
 	_MessageType = "sensor_msgs/PointCloud2";
 }
 
 bool USensorMsgsPointCloud2Converter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	bool KeyFound = false;
-	bson_t *b = message->full_msg_bson_;
-
-	auto p = new ROSMessages::sensor_msgs::PointCloud2;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-
-	KeyFound = UStdMsgsHeaderConverter::_bson_extract_child_header(b, TEXT("msg.header"), &p->header); if (!KeyFound) return false;
-
-	p->height = GetInt32FromBSON("msg.height", b, KeyFound); if (!KeyFound) return false;
-	p->width = GetInt32FromBSON("msg.width", b, KeyFound); if (!KeyFound) return false;
-
-	p->fields = GetTArrayFromBSON<ROSMessages::sensor_msgs::PointCloud2::PointField>(FString("msg.fields"), b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) {
-		ROSMessages::sensor_msgs::PointCloud2::PointField ret;
-		ret.name = GetFStringFromBSON(subKey + ".name", subMsg, subKeyFound);
-		ret.offset = GetInt32FromBSON(subKey + ".offset", subMsg, subKeyFound);
-		ret.datatype = static_cast<ROSMessages::sensor_msgs::PointCloud2::PointField::EType>( GetInt32FromBSON(subKey + ".datatype", subMsg, subKeyFound) );
-		ret.count = GetInt32FromBSON(subKey + ".count", subMsg, subKeyFound);
-		return ret;
-	});
-	if (!KeyFound) return false;
-
-	p->is_bigendian = GetBoolFromBSON("msg.is_bigendian", b, KeyFound); if (!KeyFound) return false;
-	p->is_dense = GetBoolFromBSON("msg.is_dense", b, KeyFound); if (!KeyFound) return false;
-	p->point_step = GetInt32FromBSON("msg.point_step", b, KeyFound); if (!KeyFound) return false;
-	p->row_step = GetInt32FromBSON("msg.row_step", b, KeyFound); if (!KeyFound) return false;
-
-	uint32_t binSize = 0;
-	p->data_ptr = rosbridge2cpp::Helper::get_binary_by_key("msg.data", *b, binSize, KeyFound);
-
-	return KeyFound;
+	auto msg = new ROSMessages::sensor_msgs::PointCloud2;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_point_cloud2(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsPointCloud2Converter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto PointCloud2 = StaticCastSharedPtr<ROSMessages::sensor_msgs::PointCloud2>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::PointCloud2>(BaseMsg);
 	*message = bson_new();
-	UStdMsgsHeaderConverter::_bson_append_child_header(*message, "header", &(PointCloud2->header));
-
-	BSON_APPEND_INT32(*message, "height", PointCloud2->height);
-	BSON_APPEND_INT32(*message, "width", PointCloud2->width);
-
-	_bson_append_tarray<ROSMessages::sensor_msgs::PointCloud2::PointField>(*message, "fields", PointCloud2->fields, [] (bson_t* msg, const char* key, const ROSMessages::sensor_msgs::PointCloud2::PointField& point_field)
-	{
-		bson_t PointField;
-		BSON_APPEND_DOCUMENT_BEGIN(msg, key, &PointField);
-		{
-			BSON_APPEND_UTF8(&PointField, "name", TCHAR_TO_UTF8(*point_field.name));
-			BSON_APPEND_INT32(&PointField, "offset", point_field.offset);
-			BSON_APPEND_INT32(&PointField, "datatype", (int)point_field.datatype);
-			BSON_APPEND_INT32(&PointField, "count", point_field.count);
-		}
-		bson_append_document_end(msg, &PointField);
-	});
-
-	BSON_APPEND_BOOL(*message, "is_bigendian", PointCloud2->is_bigendian);
-	BSON_APPEND_INT32(*message, "point_step", PointCloud2->point_step);
-	BSON_APPEND_INT32(*message, "row_step", PointCloud2->row_step);
-
-	bson_append_binary(*message, "data", -1, BSON_SUBTYPE_BINARY, PointCloud2->data_ptr, PointCloud2->height * PointCloud2->row_step);
-	BSON_APPEND_BOOL(*message, "is_dense", PointCloud2->is_dense);
+	_bson_append_point_cloud2(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsPointCloud2Converter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsPointCloud2Converter.h
@@ -1,19 +1,80 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
+#include "sensor_msgs/PointCloud2.h"
 #include "SensorMsgsPointCloud2Converter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsPointCloud2Converter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsPointCloud2Converter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
+
+	static bool _bson_extract_child_point_cloud2(bson_t *b, FString key, ROSMessages::sensor_msgs::PointCloud2 *msg)
+	{
+		bool KeyFound = false;
+
+		if (!UStdMsgsHeaderConverter::_bson_extract_child_header(b, key + ".header", &msg->header)) return false;
+		msg->height = GetInt32FromBSON(key + ".height", b, KeyFound); if (!KeyFound) return false;
+		msg->width = GetInt32FromBSON(key + ".width", b, KeyFound); if (!KeyFound) return false;
+
+		msg->fields = GetTArrayFromBSON<ROSMessages::sensor_msgs::PointCloud2::PointField>(key + ".fields", b, KeyFound, [](FString subKey, bson_t* subMsg, bool& subKeyFound) {
+			ROSMessages::sensor_msgs::PointCloud2::PointField ret;
+			ret.name = GetFStringFromBSON(subKey + ".name", subMsg, subKeyFound);
+			ret.offset = GetInt32FromBSON(subKey + ".offset", subMsg, subKeyFound);
+			ret.datatype = static_cast<ROSMessages::sensor_msgs::PointCloud2::PointField::EType>( GetInt32FromBSON(subKey + ".datatype", subMsg, subKeyFound) );
+			ret.count = GetInt32FromBSON(subKey + ".count", subMsg, subKeyFound);
+			return ret;
+		});
+		if (!KeyFound) return false;
+
+		msg->is_bigendian = GetBoolFromBSON(key + ".is_bigendian", b, KeyFound); if (!KeyFound) return false;
+		msg->is_dense = GetBoolFromBSON(key + ".is_dense", b, KeyFound); if (!KeyFound) return false;
+		msg->point_step = GetInt32FromBSON(key + ".point_step", b, KeyFound); if (!KeyFound) return false;
+		msg->row_step = GetInt32FromBSON(key + ".row_step", b, KeyFound); if (!KeyFound) return false;
+		msg->data_ptr = GetBinaryFromBSON(key + ".data", b, KeyFound); if (!KeyFound) return false;
+
+		return true;
+	}
+
+	static void _bson_append_child_point_cloud2(bson_t *b, const char *key, const ROSMessages::sensor_msgs::PointCloud2 *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_point_cloud2(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+	static void _bson_append_point_cloud2(bson_t *b, const ROSMessages::sensor_msgs::PointCloud2 *msg)
+	{
+		UStdMsgsHeaderConverter::_bson_append_child_header(b, "header", &msg->header);
+		BSON_APPEND_INT32(b, "height", msg->height);
+		BSON_APPEND_INT32(b, "width", msg->width);
+
+		_bson_append_tarray<ROSMessages::sensor_msgs::PointCloud2::PointField>(b, "fields", msg->fields, [] (bson_t* msg, const char* key, const ROSMessages::sensor_msgs::PointCloud2::PointField& point_field)
+		{
+			bson_t PointField;
+			BSON_APPEND_DOCUMENT_BEGIN(msg, key, &PointField);
+			{
+				BSON_APPEND_UTF8(&PointField, "name", TCHAR_TO_UTF8(*point_field.name));
+				BSON_APPEND_INT32(&PointField, "offset", point_field.offset);
+				BSON_APPEND_INT32(&PointField, "datatype", (int)point_field.datatype);
+				BSON_APPEND_INT32(&PointField, "count", point_field.count);
+			}
+			bson_append_document_end(msg, &PointField);
+		});
+
+		BSON_APPEND_BOOL(b, "is_bigendian", msg->is_bigendian);
+		BSON_APPEND_INT32(b, "point_step", msg->point_step);
+		BSON_APPEND_INT32(b, "row_step", msg->row_step);
+		BSON_APPEND_BINARY(b, "data", BSON_SUBTYPE_BINARY, msg->data_ptr, msg->height * msg->row_step);
+		BSON_APPEND_BOOL(b, "is_dense", msg->is_dense);
+	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.cpp
@@ -1,25 +1,22 @@
 #include "Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.h"
 
 
-USensorMsgsRegionOfInterestConverter::USensorMsgsRegionOfInterestConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+USensorMsgsRegionOfInterestConverter::USensorMsgsRegionOfInterestConverter()
 {
 	_MessageType = "sensor_msgs/RegionOfInterest";
 }
 
 bool USensorMsgsRegionOfInterestConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg) 
 {
-	auto roi = new ROSMessages::sensor_msgs::RegionOfInterest();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(roi);
-	return _bson_extract_child_roi(message->full_msg_bson_, "msg", roi);
+	auto msg = new ROSMessages::sensor_msgs::RegionOfInterest();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_roi(message->full_msg_bson_, "msg", msg);
 }
 
 bool USensorMsgsRegionOfInterestConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
 {
-	auto ROI = StaticCastSharedPtr<ROSMessages::sensor_msgs::RegionOfInterest>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::sensor_msgs::RegionOfInterest>(BaseMsg);
 	*message = bson_new();
-	_bson_append_roi(*message, ROI.Get());
-
+	_bson_append_roi(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/sensor_msgs/SensorMsgsRegionOfInterestConverter.h
@@ -1,49 +1,48 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
-#include "sensor_msgs/RegionOfInterest.h"
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "sensor_msgs/RegionOfInterest.h"
 #include "SensorMsgsRegionOfInterestConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API USensorMsgsRegionOfInterestConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	USensorMsgsRegionOfInterestConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_roi(bson_t *b, FString key, ROSMessages::sensor_msgs::RegionOfInterest *roi, bool LogOnErrors = true)
+	static bool _bson_extract_child_roi(bson_t *b, FString key, ROSMessages::sensor_msgs::RegionOfInterest *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		roi->x_offset = GetDoubleFromBSON(key + ".x_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		roi->y_offset = GetDoubleFromBSON(key + ".y_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		roi->height = GetDoubleFromBSON(key + ".height", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		roi->width = GetDoubleFromBSON(key + ".width", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		roi->do_rectify = GetBoolFromBSON(key + ".do_rectify", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->x_offset = GetDoubleFromBSON(key + ".x_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->y_offset = GetDoubleFromBSON(key + ".y_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->height = GetDoubleFromBSON(key + ".height", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->width = GetDoubleFromBSON(key + ".width", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->do_rectify = GetBoolFromBSON(key + ".do_rectify", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		
 		return true;
 	}
 
-	static void _bson_append_child_roi(bson_t *b, const char *key, const ROSMessages::sensor_msgs::RegionOfInterest *roi)
+	static void _bson_append_child_roi(bson_t *b, const char *key, const ROSMessages::sensor_msgs::RegionOfInterest *msg)
 	{
 		bson_t child;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
-		_bson_append_roi(&child, roi);
+		_bson_append_roi(&child, msg);
 		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_roi(bson_t *b, const ROSMessages::sensor_msgs::RegionOfInterest *roi)
+	static void _bson_append_roi(bson_t *b, const ROSMessages::sensor_msgs::RegionOfInterest *msg)
 	{
-		BSON_APPEND_INT32(b, "x_offset", roi->x_offset);
-		BSON_APPEND_INT32(b, "y_offset", roi->y_offset);
-		BSON_APPEND_INT32(b, "height", roi->height);
-		BSON_APPEND_INT32(b, "width", roi->width);
-		BSON_APPEND_BOOL(b, "do_rectify", roi->do_rectify);
+		BSON_APPEND_INT32(b, "x_offset", msg->x_offset);
+		BSON_APPEND_INT32(b, "y_offset", msg->y_offset);
+		BSON_APPEND_INT32(b, "height", msg->height);
+		BSON_APPEND_INT32(b, "width", msg->width);
+		BSON_APPEND_BOOL(b, "do_rectify", msg->do_rectify);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsBoolConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsBoolConverter.cpp
@@ -4,8 +4,7 @@
 #include "Conversion/Messages/std_msgs/StdMsgsBoolConverter.h"
 
 
-UStdMsgsBoolConverter::UStdMsgsBoolConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsBoolConverter::UStdMsgsBoolConverter()
 {
 	_MessageType = "std_msgs/Bool";
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsBoolConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsBoolConverter.h
@@ -7,15 +7,14 @@
 #include "std_msgs/Bool.h"
 #include "StdMsgsBoolConverter.generated.h"
 
-/**
- * 
- */
+
 UCLASS()
-class UStdMsgsBoolConverter : public UBaseMessageConverter
+class ROSINTEGRATION_API UStdMsgsBoolConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsBoolConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 	

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32Converter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32Converter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Messages/std_msgs/StdMsgsFloat32Converter.h"
 
 
-UStdMsgsFloat32Converter::UStdMsgsFloat32Converter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsFloat32Converter::UStdMsgsFloat32Converter()
 {
 	_MessageType = "std_msgs/Float32";
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32Converter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32Converter.h
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/Float32.h"
-
 #include "StdMsgsFloat32Converter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsFloat32Converter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsFloat32Converter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.cpp
@@ -1,24 +1,21 @@
 #include "Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h"
 
-UStdMsgsFloat32MultiArrayConverter::UStdMsgsFloat32MultiArrayConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsFloat32MultiArrayConverter::UStdMsgsFloat32MultiArrayConverter()
 {
 	_MessageType = "std_msgs/Float32MultiArray";
 }
 
 bool UStdMsgsFloat32MultiArrayConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::std_msgs::Float32MultiArray;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_float_multi_array(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::std_msgs::Float32MultiArray;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_float_multi_array(message->full_msg_bson_, "msg", msg);
 }
 
 bool UStdMsgsFloat32MultiArrayConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto mad = StaticCastSharedPtr<ROSMessages::std_msgs::Float32MultiArray>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::std_msgs::Float32MultiArray>(BaseMsg);
 	*message = bson_new();
-	_bson_append_float_multi_array(*message, mad.Get());
-
+	_bson_append_float_multi_array(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsFloat32MultiArrayConverter.h
@@ -1,45 +1,43 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/Float32MultiArray.h"
 #include "Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h"
-
 #include "StdMsgsFloat32MultiArrayConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsFloat32MultiArrayConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsFloat32MultiArrayConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_float_multi_array(bson_t *b, FString key, ROSMessages::std_msgs::Float32MultiArray *fma, bool LogOnErrors = true)
+	static bool _bson_extract_child_float_multi_array(bson_t *b, FString key, ROSMessages::std_msgs::Float32MultiArray *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsMultiArrayLayoutConverter::_bson_extract_child_multi_array_layout(b, key + ".layout", &fma->layout, LogOnErrors); if (!KeyFound) return false;
-		fma->data = GetFloatTArrayFromBSON(key + ".data", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		KeyFound = UStdMsgsMultiArrayLayoutConverter::_bson_extract_child_multi_array_layout(b, key + ".layout", &msg->layout, LogOnErrors); if (!KeyFound) return false;
+		msg->data = GetFloatTArrayFromBSON(key + ".data", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_float_multi_array(bson_t *b, const char *key, const ROSMessages::std_msgs::Float32MultiArray *fma)
+	static void _bson_append_child_float_multi_array(bson_t *b, const char *key, const ROSMessages::std_msgs::Float32MultiArray *msg)
 	{
-		bson_t layout;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
-		_bson_append_float_multi_array(&layout, fma);
-		bson_append_document_end(b, &layout);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_float_multi_array(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_float_multi_array(bson_t *b, const ROSMessages::std_msgs::Float32MultiArray *fma)
+	static void _bson_append_float_multi_array(bson_t *b, const ROSMessages::std_msgs::Float32MultiArray *msg)
 	{
-		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &fma->layout);
-		_bson_append_float_tarray(b, "data", fma->data);
+		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &msg->layout);
+		_bson_append_float_tarray(b, "data", msg->data);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.cpp
@@ -1,33 +1,22 @@
 #include "Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h"
 
-#include "std_msgs/Header.h"
 
-
-UStdMsgsHeaderConverter::UStdMsgsHeaderConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsHeaderConverter::UStdMsgsHeaderConverter()
 {
 	_MessageType = "std_msgs/Header";
 }
 
 bool UStdMsgsHeaderConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::std_msgs::Header();
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_header(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::std_msgs::Header();
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_header(message->full_msg_bson_, "msg", msg);
 }
 
 bool UStdMsgsHeaderConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto h = StaticCastSharedPtr<ROSMessages::std_msgs::Header>(BaseMsg);
-
-	*message = BCON_NEW(
-		"seq", BCON_INT32(h->seq),
-		"stamp", "{",
-		"secs", BCON_INT32(h->time._Sec),
-		"nsecs", BCON_INT32(h->time._NSec),
-		"}",
-		"frame_id", BCON_UTF8(TCHAR_TO_ANSI(*h->frame_id))
-	);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::std_msgs::Header>(BaseMsg);
+	*message = bson_new();
+	_bson_append_header(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsHeaderConverter.h
@@ -1,55 +1,55 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
+#include "std_msgs/Header.h"
 #include "StdMsgsHeaderConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsHeaderConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsHeaderConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	// Helper function to extract a child-std_msgs/Header from a bson_t
-	static bool _bson_extract_child_header(bson_t *b, FString key, ROSMessages::std_msgs::Header *h, bool LogOnErrors = true)
+	static bool _bson_extract_child_header(bson_t *b, FString key, ROSMessages::std_msgs::Header *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 		
 		// TODO Check if rosbridge sends UINT64 or INT32 (there is no uint32 in bson)
-		h->seq = GetInt32FromBSON(key + ".seq", b, KeyFound, LogOnErrors);		if (!KeyFound) return false;
-		int32 Sec = GetInt32FromBSON(key + ".stamp.secs", b, KeyFound, LogOnErrors);  if (!KeyFound) return false;
-		int32 NSec = GetInt32FromBSON(key + ".stamp.nsecs", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		h->frame_id = GetFStringFromBSON(key + ".frame_id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		h->time = FROSTime(Sec, NSec);
+		msg->seq = GetInt32FromBSON(key + ".seq", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		// int32 Sec = GetInt32FromBSON(key + ".stamp.secs", b, KeyFound, LogOnErrors);  if (!KeyFound) return false;
+		// int32 NSec = GetInt32FromBSON(key + ".stamp.nsecs", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		// msg->time = FROSTime(Sec, NSec);
+		if (!_bson_extract_child_ros_time(b, key + ".stamp", &msg->time, LogOnErrors)) return false;
+		msg->frame_id = GetFStringFromBSON(key + ".frame_id", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_header(bson_t* b, const char* key, const ROSMessages::std_msgs::Header* header)
+	static void _bson_append_child_header(bson_t* b, const char* key, const ROSMessages::std_msgs::Header* msg)
 	{
 		bson_t child;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
-		_bson_append_header(&child, header);
+		_bson_append_header(&child, msg);
 		bson_append_document_end(b, &child);
 	}
 
-	static void _bson_append_header(bson_t *b, const ROSMessages::std_msgs::Header *header)
+	static void _bson_append_header(bson_t *b, const ROSMessages::std_msgs::Header *msg)
 	{
-		BSON_APPEND_INT32(b, "seq", header->seq);
+		BSON_APPEND_INT32(b, "seq", msg->seq);
 
-		bson_t stamp;
-		BSON_APPEND_DOCUMENT_BEGIN(b, "stamp", &stamp);
-		BSON_APPEND_INT32(&stamp, "secs", header->time._Sec);
-		BSON_APPEND_INT32(&stamp, "nsecs", header->time._NSec);
-		bson_append_document_end(b, &stamp);
+		// bson_t stamp;
+		// BSON_APPEND_DOCUMENT_BEGIN(b, "stamp", &stamp);
+		// BSON_APPEND_INT32(&stamp, "secs", header->time._Sec);
+		// BSON_APPEND_INT32(&stamp, "nsecs", header->time._NSec);
+		// bson_append_document_end(b, &stamp);
+		_bson_append_child_ros_time(b, "stamp", &msg->time);
 
-		BSON_APPEND_UTF8(b, "frame_id", TCHAR_TO_UTF8(*header->frame_id));
+		BSON_APPEND_UTF8(b, "frame_id", TCHAR_TO_UTF8(*msg->frame_id));
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.cpp
@@ -1,24 +1,21 @@
 #include "Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h"
 
-UStdMsgsMultiArrayDimensionConverter::UStdMsgsMultiArrayDimensionConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsMultiArrayDimensionConverter::UStdMsgsMultiArrayDimensionConverter()
 {
 	_MessageType = "std_msgs/MultiArrayDimension";
 }
 
 bool UStdMsgsMultiArrayDimensionConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::std_msgs::MultiArrayDimension;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_multi_array_dimension(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::std_msgs::MultiArrayDimension;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_multi_array_dimension(message->full_msg_bson_, "msg", msg);
 }
 
 bool UStdMsgsMultiArrayDimensionConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto mad = StaticCastSharedPtr<ROSMessages::std_msgs::MultiArrayDimension>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::std_msgs::MultiArrayDimension>(BaseMsg);
 	*message = bson_new();
-	_bson_append_multi_array_dimension(*message, mad.Get());
-
+	_bson_append_multi_array_dimension(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h
@@ -1,46 +1,44 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/MultiArrayDimension.h"
-
 #include "StdMsgsMultiArrayDimensionConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsMultiArrayDimensionConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsMultiArrayDimensionConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_multi_array_dimension(bson_t *b, FString key, ROSMessages::std_msgs::MultiArrayDimension *mad, bool LogOnErrors = true)
+	static bool _bson_extract_child_multi_array_dimension(bson_t *b, FString key, ROSMessages::std_msgs::MultiArrayDimension *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		mad->label = GetFStringFromBSON(key + ".label", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		mad->size = GetInt32FromBSON(key + ".size", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
-		mad->stride = GetInt32FromBSON(key + ".stride", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->label = GetFStringFromBSON(key + ".label", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->size = GetInt32FromBSON(key + ".size", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->stride = GetInt32FromBSON(key + ".stride", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 		return true;
 	}
 
-	static void _bson_append_child_multi_array_dimension(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayDimension *mad)
+	static void _bson_append_child_multi_array_dimension(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayDimension *msg)
 	{
-		bson_t m;
-		BSON_APPEND_DOCUMENT_BEGIN(b, key, &m);
-		_bson_append_multi_array_dimension(&m, mad);
-		bson_append_document_end(b, &m);
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_multi_array_dimension(&child, msg);
+		bson_append_document_end(b, &child);
 	}
 
 
-	static void _bson_append_multi_array_dimension(bson_t *b, const ROSMessages::std_msgs::MultiArrayDimension *mad)
+	static void _bson_append_multi_array_dimension(bson_t *b, const ROSMessages::std_msgs::MultiArrayDimension *msg)
 	{
-		BSON_APPEND_UTF8(b, "label", TCHAR_TO_UTF8(*mad->label));
-		BSON_APPEND_INT32(b, "size", mad->size);
-		BSON_APPEND_INT32(b, "stride", mad->stride);
+		BSON_APPEND_UTF8(b, "label", TCHAR_TO_UTF8(*msg->label));
+		BSON_APPEND_INT32(b, "size", msg->size);
+		BSON_APPEND_INT32(b, "stride", msg->stride);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.cpp
@@ -1,25 +1,22 @@
 #include "StdMsgsMultiArrayLayoutConverter.h"
 
 
-UStdMsgsMultiArrayLayoutConverter::UStdMsgsMultiArrayLayoutConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsMultiArrayLayoutConverter::UStdMsgsMultiArrayLayoutConverter()
 {
 	_MessageType = "std_msgs/MultiArrayLayout";
 }
 
 bool UStdMsgsMultiArrayLayoutConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::std_msgs::MultiArrayLayout;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_multi_array_layout(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::std_msgs::MultiArrayLayout;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_multi_array_layout(message->full_msg_bson_, "msg", msg);
 }
 
 bool UStdMsgsMultiArrayLayoutConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto Pose = StaticCastSharedPtr<ROSMessages::std_msgs::MultiArrayLayout>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::std_msgs::MultiArrayLayout>(BaseMsg);
 	*message = bson_new();
-	_bson_append_multi_array_layout(*message, Pose.Get());
-
+	_bson_append_multi_array_layout(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h
@@ -1,29 +1,27 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/MultiArrayLayout.h"
 #include "Conversion/Messages/std_msgs/StdMsgsMultiArrayDimensionConverter.h"
-
 #include "StdMsgsMultiArrayLayoutConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsMultiArrayLayoutConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsMultiArrayLayoutConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_multi_array_layout(bson_t *b, FString key, ROSMessages::std_msgs::MultiArrayLayout *mal, bool LogOnErrors = true)
+	static bool _bson_extract_child_multi_array_layout(bson_t *b, FString key, ROSMessages::std_msgs::MultiArrayLayout *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		mal->dim = GetTArrayFromBSON<ROSMessages::std_msgs::MultiArrayDimension>(key + ".dim", b, KeyFound, [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound)
+		msg->dim = GetTArrayFromBSON<ROSMessages::std_msgs::MultiArrayDimension>(key + ".dim", b, KeyFound, [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound)
 		{
 			ROSMessages::std_msgs::MultiArrayDimension ret;
 			subKeyFound = UStdMsgsMultiArrayDimensionConverter::_bson_extract_child_multi_array_dimension(subMsg, subKey, &ret, LogOnErrors);
@@ -31,25 +29,25 @@ public:
 		}, LogOnErrors);
 		if (!KeyFound) return false;
 
-		mal->data_offset = GetInt32FromBSON(key + ".data_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
+		msg->data_offset = GetInt32FromBSON(key + ".data_offset", b, KeyFound, LogOnErrors); if (!KeyFound) return false;
 
 		return true;
 	}
 
-	static void _bson_append_child_multi_array_layout(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayLayout *mal)
+	static void _bson_append_child_multi_array_layout(bson_t *b, const char *key, const ROSMessages::std_msgs::MultiArrayLayout *msg)
 	{
 		bson_t layout;
 		BSON_APPEND_DOCUMENT_BEGIN(b, key, &layout);
-		_bson_append_multi_array_layout(&layout, mal);
+		_bson_append_multi_array_layout(&layout, msg);
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_multi_array_layout(bson_t *b, const ROSMessages::std_msgs::MultiArrayLayout *mal)
+	static void _bson_append_multi_array_layout(bson_t *b, const ROSMessages::std_msgs::MultiArrayLayout *msg)
 	{
-		_bson_append_tarray<ROSMessages::std_msgs::MultiArrayDimension>(b, "dim", mal->dim, [](bson_t *subb, const char *subKey, ROSMessages::std_msgs::MultiArrayDimension mad)
+		_bson_append_tarray<ROSMessages::std_msgs::MultiArrayDimension>(b, "dim", msg->dim, [](bson_t *subb, const char *subKey, ROSMessages::std_msgs::MultiArrayDimension mad)
 		{
 			UStdMsgsMultiArrayDimensionConverter::_bson_append_child_multi_array_dimension(subb, subKey, &mad);
 		});
-		BSON_APPEND_INT32(b, "data_offset", mal->data_offset);
+		BSON_APPEND_INT32(b, "data_offset", msg->data_offset);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsStringConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsStringConverter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Messages/std_msgs/StdMsgsStringConverter.h"
 
 
-UStdMsgsStringConverter::UStdMsgsStringConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsStringConverter::UStdMsgsStringConverter()
 {
 	_MessageType = "std_msgs/String";
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsStringConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsStringConverter.h
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/String.h"
-
 #include "StdMsgsStringConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsStringConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsStringConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.cpp
@@ -1,24 +1,21 @@
 #include "Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.h"
 
-UStdMsgsUInt8MultiArrayConverter::UStdMsgsUInt8MultiArrayConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UStdMsgsUInt8MultiArrayConverter::UStdMsgsUInt8MultiArrayConverter()
 {
 	_MessageType = "std_msgs/UInt8MultiArray";
 }
 
 bool UStdMsgsUInt8MultiArrayConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg)
 {
-	auto p = new ROSMessages::std_msgs::UInt8MultiArray;
-	BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-	return _bson_extract_child_uint8_multi_array(message->full_msg_bson_, "msg", p);
+	auto msg = new ROSMessages::std_msgs::UInt8MultiArray;
+	BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_uint8_multi_array(message->full_msg_bson_, "msg", msg);
 }
 
 bool UStdMsgsUInt8MultiArrayConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message)
 {
-	auto bma = StaticCastSharedPtr<ROSMessages::std_msgs::UInt8MultiArray>(BaseMsg);
-
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::std_msgs::UInt8MultiArray>(BaseMsg);
 	*message = bson_new();
-	_bson_append_uint8_multi_array(*message, bma.Get());
-
+	_bson_append_uint8_multi_array(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/std_msgs/StdMsgsUInt8MultiArrayConverter.h
@@ -1,30 +1,28 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "std_msgs/UInt8MultiArray.h"
 #include "Conversion/Messages/std_msgs/StdMsgsMultiArrayLayoutConverter.h"
-
 #include "StdMsgsUInt8MultiArrayConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UStdMsgsUInt8MultiArrayConverter : public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UStdMsgsUInt8MultiArrayConverter();
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-	static bool _bson_extract_child_uint8_multi_array(bson_t *b, FString key, ROSMessages::std_msgs::UInt8MultiArray *bma, bool LogOnErrors = true)
+	static bool _bson_extract_child_uint8_multi_array(bson_t *b, FString key, ROSMessages::std_msgs::UInt8MultiArray *msg, bool LogOnErrors = true)
 	{
 		bool KeyFound = false;
 
-		KeyFound = UStdMsgsMultiArrayLayoutConverter::_bson_extract_child_multi_array_layout(b, key + ".layout", &bma->layout, LogOnErrors); if (!KeyFound) return false;
-		bma->data = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*(key + ".data")), *b, bma->layout.dim[0].size, KeyFound);
+		KeyFound = UStdMsgsMultiArrayLayoutConverter::_bson_extract_child_multi_array_layout(b, key + ".layout", &msg->layout, LogOnErrors); if (!KeyFound) return false;
+		msg->data = rosbridge2cpp::Helper::get_binary_by_key(TCHAR_TO_UTF8(*(key + ".data")), *b, msg->layout.dim[0].size, KeyFound);
 
 		return true;
 	}
@@ -37,9 +35,9 @@ public:
 		bson_append_document_end(b, &layout);
 	}
 
-	static void _bson_append_uint8_multi_array(bson_t *b, const ROSMessages::std_msgs::UInt8MultiArray *bma)
+	static void _bson_append_uint8_multi_array(bson_t *b, const ROSMessages::std_msgs::UInt8MultiArray *msg)
 	{
-		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &bma->layout);
-		bson_append_binary(b, "data", -1, BSON_SUBTYPE_BINARY, bma->data, bma->layout.dim[0].size);
+		UStdMsgsMultiArrayLayoutConverter::_bson_append_child_multi_array_layout(b, "layout", &msg->layout);
+		bson_append_binary(b, "data", -1, BSON_SUBTYPE_BINARY, msg->data, msg->layout.dim[0].size);
 	}
 };

--- a/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
@@ -1,61 +1,26 @@
 #include "Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.h"
 
-#include "tf2_msgs/TFMessage.h"
 
-
-UTf2MsgsTFMessageConverter::UTf2MsgsTFMessageConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UTf2MsgsTFMessageConverter::UTf2MsgsTFMessageConverter()
 {
 	_MessageType = "tf2_msgs/TFMessage";
 }
 
-bool UTf2MsgsTFMessageConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg) {
-//    UE_LOG(LogTemp, Display , TEXT("ROSIntegration: TFMessage received"));
-    auto p = new ROSMessages::tf2_msgs::TFMessage;
-    BaseMsg = TSharedPtr<FROSBaseMsg>(p);
-    bool keyFound = false;
-    p->transforms = GetTFMessageTArrayFromBSON("msg.transforms", message->full_msg_bson_, keyFound, false);
-	return keyFound;
+bool UTf2MsgsTFMessageConverter::ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg) 
+{
+    auto msg = new ROSMessages::tf2_msgs::TFMessage;
+    BaseMsg = TSharedPtr<FROSBaseMsg>(msg);
+	return _bson_extract_child_tf2_msg(message->full_msg_bson_, "msg", msg);
 }
 
-bool UTf2MsgsTFMessageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) {
-	auto TFMessage = StaticCastSharedPtr<ROSMessages::tf2_msgs::TFMessage>(BaseMsg);
-	if (TFMessage->transforms.Num() == 0) {
+bool UTf2MsgsTFMessageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
+{
+	auto CastMsg = StaticCastSharedPtr<ROSMessages::tf2_msgs::TFMessage>(BaseMsg);
+	if (CastMsg->transforms.Num() == 0) 
+	{
 		UE_LOG(LogTemp, Warning, TEXT("No transform saved in TFMessage. Can't convert message"));
 		return false;
 	}
-
-	auto FirstTFMessage = TFMessage->transforms[0];
-
-	*message = BCON_NEW(
-		"transforms",
-		"[",
-		"{",
-		"header", "{",
-		"seq", BCON_INT32(FirstTFMessage.header.seq),
-		"stamp", "{",
-		"secs", BCON_INT32(FirstTFMessage.header.time._Sec),
-		"nsecs", BCON_INT32(FirstTFMessage.header.time._NSec),
-		"}",
-		"frame_id", BCON_UTF8(TCHAR_TO_ANSI(*FirstTFMessage.header.frame_id)),
-		"}",
-		"child_frame_id", BCON_UTF8(TCHAR_TO_ANSI(*FirstTFMessage.child_frame_id)),
-		"transform", "{",
-		"translation", "{",
-		"x", BCON_DOUBLE(FirstTFMessage.transform.translation.x),
-		"y", BCON_DOUBLE(FirstTFMessage.transform.translation.y),
-		"z", BCON_DOUBLE(FirstTFMessage.transform.translation.z),
-		"}",
-		"rotation", "{",
-		"x", BCON_DOUBLE(FirstTFMessage.transform.rotation.x),
-		"y", BCON_DOUBLE(FirstTFMessage.transform.rotation.y),
-		"z", BCON_DOUBLE(FirstTFMessage.transform.rotation.z),
-		"w", BCON_DOUBLE(FirstTFMessage.transform.rotation.w),
-		"}",
-		"}",
-		"}",
-		"]"
-	);
-
+	_bson_append_tf2_msg(*message, CastMsg.Get());
 	return true;
 }

--- a/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.h
@@ -1,31 +1,31 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
 #include "Conversion/Messages/geometry_msgs/GeometryMsgsTransformStampedConverter.h"
-
+#include "tf2_msgs/TFMessage.h"
 #include "Tf2MsgsTFMessageConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API UTf2MsgsTFMessageConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+    UTf2MsgsTFMessageConverter();
+
 	virtual bool ConvertIncomingMessage(const ROSBridgePublishMsg* message, TSharedPtr<FROSBaseMsg> &BaseMsg);
 	virtual bool ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message);
 
-    static ROSMessages::geometry_msgs::TransformStamped GetTransformStampedFromBSON(FString key, bson_t* msg, bool &keyFound, bool LogOnErrors = true)
+    static ROSMessages::geometry_msgs::TransformStamped GetTransformStampedFromBSON(FString key, bson_t* b, bool &keyFound, bool LogOnErrors = true)
     {
-        auto p = new ROSMessages::geometry_msgs::TransformStamped;
-        keyFound = UGeometryMsgsTransformStampedConverter::_bson_extract_child_transform_stamped(msg, key, p, LogOnErrors);
+        auto msg = new ROSMessages::geometry_msgs::TransformStamped;
+        keyFound = UGeometryMsgsTransformStampedConverter::_bson_extract_child_transform_stamped(b, key, msg, LogOnErrors);
         if (!keyFound && LogOnErrors) {
             UE_LOG(LogTemp, Error, TEXT("Key %s is not present in data"), *key);
         }
-        return *p;
+        return *msg;
     }
 
     static TArray<ROSMessages::geometry_msgs::TransformStamped> GetTFMessageTArrayFromBSON(FString Key, bson_t* msg, bool &KeyFound, bool LogOnErrors = true)
@@ -34,5 +34,28 @@ public:
                 Key, msg, KeyFound, 
                 [LogOnErrors](FString subKey, bson_t* subMsg, bool& subKeyFound) { return GetTransformStampedFromBSON(subKey, subMsg, subKeyFound, LogOnErrors); },
             LogOnErrors);
+    }
+
+    static bool _bson_extract_child_tf2_msg(bson_t *b, FString key, ROSMessages::tf2_msgs::TFMessage *msg, bool LogOnErrors = true)
+    {
+        bool keyFound = false;
+        msg->transforms = GetTFMessageTArrayFromBSON(key + ".transforms", b, keyFound, false);
+        return keyFound;
+    }
+
+    static void _bson_append_child_tf2_msg(bson_t *b, const char *key, const ROSMessages::tf2_msgs::TFMessage *msg)
+	{
+		bson_t child;
+		BSON_APPEND_DOCUMENT_BEGIN(b, key, &child);
+		_bson_append_tf2_msg(&child, msg);
+		bson_append_document_end(b, &child);
+	}
+
+    static void _bson_append_tf2_msg(bson_t *b, const ROSMessages::tf2_msgs::TFMessage *msg)
+    {
+        _bson_append_tarray<ROSMessages::geometry_msgs::TransformStamped>(b, "transforms", msg->transforms, [](bson_t* msg, const char* key, const ROSMessages::geometry_msgs::TransformStamped& elem)
+		{
+			UGeometryMsgsTransformStampedConverter::_bson_append_child_transform_stamped(msg, key, &elem);
+		});
     }
 };

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Services/BaseRequestConverter.h"
 
 
-UBaseRequestConverter::UBaseRequestConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UBaseRequestConverter::UBaseRequestConverter()
 {
 }
 

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.h
@@ -1,22 +1,20 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "rosbridge2cpp/messages/rosbridge_call_service_msg.h"
 #include "ROSBaseServiceRequest.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-#include <bson.h>
-
 #include "BaseRequestConverter.generated.h"
 
 
 UCLASS()
-class ROSINTEGRATION_API UBaseRequestConverter: public UObject
+class ROSINTEGRATION_API UBaseRequestConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UBaseRequestConverter();
+
 	UPROPERTY()
 	FString _ServiceType;
 

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseRequestConverter.h
@@ -5,6 +5,7 @@
 #include <UObject/Object.h>
 #include "rosbridge2cpp/messages/rosbridge_call_service_msg.h"
 #include "ROSBaseServiceRequest.h"
+#include "Conversion/Messages/BaseMessageConverter.h"
 #include <bson.h>
 
 #include "BaseRequestConverter.generated.h"

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.cpp
@@ -1,8 +1,7 @@
 #include "Conversion/Services/BaseResponseConverter.h"
 
 
-UBaseResponseConverter::UBaseResponseConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+UBaseResponseConverter::UBaseResponseConverter()
 {
 }
 

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.h
@@ -1,21 +1,20 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "rosbridge2cpp/messages/rosbridge_service_response_msg.h"
 #include "ROSBaseServiceResponse.h"
 #include "Conversion/Messages/BaseMessageConverter.h"
-
 #include "BaseResponseConverter.generated.h"
 
 
 UCLASS()
-class ROSINTEGRATION_API UBaseResponseConverter: public UObject
+class ROSINTEGRATION_API UBaseResponseConverter: public UBaseMessageConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	UBaseResponseConverter();
+
 	UPROPERTY()
 	FString _ServiceType;
 

--- a/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/BaseResponseConverter.h
@@ -5,6 +5,7 @@
 #include <UObject/Object.h>
 #include "rosbridge2cpp/messages/rosbridge_service_response_msg.h"
 #include "ROSBaseServiceResponse.h"
+#include "Conversion/Messages/BaseMessageConverter.h"
 
 #include "BaseResponseConverter.generated.h"
 

--- a/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsRequestConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsRequestConverter.cpp
@@ -2,8 +2,7 @@
 #include "rospy_tutorials/AddTwoIntsRequest.h"
 
 
-URospyTutorialsAddTwoIntsRequestConverter::URospyTutorialsAddTwoIntsRequestConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+URospyTutorialsAddTwoIntsRequestConverter::URospyTutorialsAddTwoIntsRequestConverter()
 {
 	_ServiceType = "rospy_tutorials/AddTwoInts";
 }

--- a/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsRequestConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsRequestConverter.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Services/BaseRequestConverter.h"
 
 #include "RospyTutorialsAddTwoIntsRequestConverter.generated.h"
@@ -11,9 +9,10 @@
 UCLASS()
 class ROSINTEGRATION_API URospyTutorialsAddTwoIntsRequestConverter: public UBaseRequestConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	URospyTutorialsAddTwoIntsRequestConverter();
 	virtual bool ConvertIncomingRequest(ROSBridgeCallServiceMsg &req, TSharedPtr<FROSBaseServiceRequest> Request) override;
 	virtual bool ConvertOutgoingRequest(TSharedPtr<FROSBaseServiceRequest> Request, bson_t** BSONRequest) override;
 

--- a/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsResponseConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsResponseConverter.cpp
@@ -4,8 +4,7 @@
 #include <bson.h>
 
 
-URospyTutorialsAddTwoIntsResponseConverter::URospyTutorialsAddTwoIntsResponseConverter(const FObjectInitializer& ObjectInitializer)
-: Super(ObjectInitializer)
+URospyTutorialsAddTwoIntsResponseConverter::URospyTutorialsAddTwoIntsResponseConverter()
 {
 	_ServiceType = "rospy_tutorials/AddTwoInts";
 }

--- a/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsResponseConverter.h
+++ b/Source/ROSIntegration/Private/Conversion/Services/rospy_tutorials/RospyTutorialsAddTwoIntsResponseConverter.h
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <CoreMinimal.h>
-#include <UObject/ObjectMacros.h>
-#include <UObject/Object.h>
+#include "CoreMinimal.h"
 #include "Conversion/Services/BaseResponseConverter.h"
-
 #include "RospyTutorialsAddTwoIntsResponseConverter.generated.h"
 
 
 UCLASS()
 class ROSINTEGRATION_API URospyTutorialsAddTwoIntsResponseConverter: public UBaseResponseConverter
 {
-	GENERATED_UCLASS_BODY()
+	GENERATED_BODY()
 
 public:
+	URospyTutorialsAddTwoIntsResponseConverter();
 	virtual bool ConvertIncomingResponse(const ROSBridgeServiceResponseMsg &res, TSharedRef<TSharedPtr<FROSBaseServiceResponse>> Response) override;
 	virtual bool ConvertOutgoingResponse(TSharedPtr<FROSBaseServiceResponse> Response, ROSBridgeServiceResponseMsg &res) override;
 

--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -121,7 +121,7 @@ public:
 				if (It->IsChildOf(UBaseMessageConverter::StaticClass()) && *It != UBaseMessageConverter::StaticClass())
 				{
 					UBaseMessageConverter* ConcreteConverter = ClassItr->GetDefaultObject<UBaseMessageConverter>();
-					//UE_LOG(LogROS, Log, TEXT("Added %s with type %s to TopicConverterMap"), *(It->GetDefaultObjectName().ToString()), *(ConcreteConverter->_MessageType));
+					// UE_LOG(LogROS, Log, TEXT("Added %s with type %s to TopicConverterMap"), *(It->GetDefaultObjectName().ToString()), *(ConcreteConverter->_MessageType));
 					TypeConverterMap.Add(*(ConcreteConverter->_MessageType), ConcreteConverter);
 				}
 			}

--- a/Source/ROSIntegration/Private/rosbridge2cpp/helper.h
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/helper.h
@@ -64,6 +64,23 @@ namespace rosbridge2cpp {
 		}
 
 		// dot_notation refers to MongoDB dot notation
+		// returns INT32_MAX and sets success to 'false' if suitable data can't be found via the dot notation
+		int64_t static get_int64_by_key(const char *dot_notation, bson_t &b, bool &success)
+		{
+			bson_iter_t iter;
+			bson_iter_t val;
+
+			if (bson_iter_init(&iter, &b) &&
+				bson_iter_find_descendant(&iter, dot_notation, &val) &&
+				BSON_ITER_HOLDS_INT64(&val)) {
+				success = true;
+				return bson_iter_int64(&val);
+			}
+			success = false;
+			return INT64_MAX;
+		}
+
+		// dot_notation refers to MongoDB dot notation
 		// returns -1 and sets success to 'false' if suitable data can't be found via the dot notation
 		double static get_double_by_key(const char *dot_notation, bson_t &b, bool &success)
 		{

--- a/Source/ROSIntegration/Public/geometry_msgs/PoseWithCovariance.h
+++ b/Source/ROSIntegration/Public/geometry_msgs/PoseWithCovariance.h
@@ -14,6 +14,8 @@ namespace ROSMessages {
 			}
 
 			geometry_msgs::Pose pose;
+
+			// Row-major representation of the 6x6 covariance matrix
 			TArray<double> covariance;
 		};
 	}

--- a/Source/ROSIntegration/Public/geometry_msgs/Quaternion.h
+++ b/Source/ROSIntegration/Public/geometry_msgs/Quaternion.h
@@ -6,7 +6,7 @@ namespace ROSMessages{
 	namespace geometry_msgs {
 		class Quaternion: public FROSBaseMsg {
 		public:
-			Quaternion() : Quaternion(0, 0, 0, 0) {}
+			Quaternion() : Quaternion(0, 0, 0, 1) {} // Base quaternion should be the identity quaternion
 
 			Quaternion(double x, double y, double z, double w) : x(x), y(y), z(z), w(w){
 				_MessageType = "geometry_msgs/Quaternion";

--- a/Source/ROSIntegration/Public/geometry_msgs/Quaternion.h
+++ b/Source/ROSIntegration/Public/geometry_msgs/Quaternion.h
@@ -6,7 +6,7 @@ namespace ROSMessages{
 	namespace geometry_msgs {
 		class Quaternion: public FROSBaseMsg {
 		public:
-			Quaternion() : Quaternion(0, 0, 0, 1) {} // Base quaternion should be the identity quaternion
+			Quaternion() : Quaternion(0, 0, 0, 0) {}
 
 			Quaternion(double x, double y, double z, double w) : x(x), y(y), z(z), w(w){
 				_MessageType = "geometry_msgs/Quaternion";

--- a/Source/ROSIntegration/Public/geometry_msgs/TwistStamped.h
+++ b/Source/ROSIntegration/Public/geometry_msgs/TwistStamped.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "ROSBaseMsg.h"
+
+#include "std_msgs/Header.h"
+#include "geometry_msgs/Twist.h"
+
+namespace ROSMessages {
+	namespace geometry_msgs {
+		class TwistStamped : public FROSBaseMsg {
+		public:
+			TwistStamped() {
+				_MessageType = "geometry_msgs/TwistStamped";
+			}
+
+			std_msgs::Header header;
+			geometry_msgs::Twist twist;
+		};
+	}
+}

--- a/Source/ROSIntegration/Public/geometry_msgs/TwistWithCovariance.h
+++ b/Source/ROSIntegration/Public/geometry_msgs/TwistWithCovariance.h
@@ -14,6 +14,8 @@ namespace ROSMessages {
 			}
 
 			geometry_msgs::Twist twist;
+
+			// Row-major representation of the 6x6 covariance matrix
 			TArray<double> covariance;
 		};
 	}


### PR DESCRIPTION
I finally got around to cleaning up my own fork of this repo which contains cleaner converters and numerous additions/improvements. I have not observed any errors/problems with making these changes on my end

Summary of changes:
1. Removed FObjectInitializer from msg/srv converters. The FObjectInitializer is unnecessary in most applications and it was never used for anything. Since UE4 no longer requires it, removing it does not affect anything.
2. Cleaned up msg/srv converters to adhere to the same common format (all have helper static functions in header files, as some were missing, and I wanted everything to read cleaner in general)
3. Added missing Super:: calls per request in https://github.com/code-iai/ROSIntegration/issues/165
4. Added more helper functions to the BaseMessageConverter() class for user convenience.
5. BaseRequestConverter() and BaseResponseConverter() are now child classes of BaseMessageConverter() so they can access the same BSON helper functions.
6. Updated README regarding installation of rosbridge. Users should now install rosbridge from source with the `ros1` branch as this seems to work fine now (I commented out the original "important" text in the readme just in case).