### PR TITLE
Added Websocket Support

### DIFF
--- a/Config/Engine.ini
+++ b/Config/Engine.ini
@@ -1,0 +1,2 @@
+[WebSockets.LibWebSockets]
+ThreadTargetFrameTimeInSeconds = 0.0

--- a/Source/ROSIntegration/Classes/ROSBridgeParamOverride.h
+++ b/Source/ROSIntegration/Classes/ROSBridgeParamOverride.h
@@ -20,6 +20,10 @@ public:
         PrimaryActorTick.bCanEverTick = false; // No need to tick
     }
 
+	// Protocol for connecting to rosbridge websocket server, use "tcp" or "ws"
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
+	FString ROSBridgeServerProtocol = "tcp";
+
     // IP address of the rosbridge websocket server
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
 	FString ROSBridgeServerHost = "127.0.0.1";

--- a/Source/ROSIntegration/Classes/ROSIntegrationCore.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationCore.h
@@ -64,7 +64,7 @@ public:
 
 	~UROSIntegrationCore();
 
-	bool Init(FString ROSBridgeHost, int32 ROSBridgePort);
+	bool Init(FString protocol, FString ROSBridgeHost, int32 ROSBridgePort);
 
 	bool IsHealthy() const;
 

--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -23,6 +23,9 @@ public:
 	UROSIntegrationCore* ROSIntegrationCore = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
+	FString ROSBridgeServerProtocol = "tcp";
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")
 	FString ROSBridgeServerHost = "127.0.0.1";
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ROS")

--- a/Source/ROSIntegration/Private/ROSIntegrationCore.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationCore.cpp
@@ -1,6 +1,7 @@
 #include "ROSIntegrationCore.h"
 #include "ROSIntegrationGameInstance.h"
 #include "rosbridge2cpp/TCPConnection.h"
+#include "rosbridge2cpp/WebsocketConnection.h"
 #include "rosbridge2cpp/ros_bridge.h"
 #include "rosbridge2cpp/ros_topic.h"
 
@@ -23,12 +24,13 @@ DEFINE_LOG_CATEGORY(LogROS);
 class UImpl::Impl
 {
 	// hidden implementation details
+	TCPConnection* _TCPConnection = nullptr;
+	WebsocketConnection* _WebsocketConnection = nullptr;
+	rosbridge2cpp::ROSBridge* _Ros = nullptr;
 public:
 	bool _bson_test_mode;
 
-	TCPConnection _Connection;
-	rosbridge2cpp::ROSBridge _Ros{ _Connection };
-
+	rosbridge2cpp::ROSBridge& GetBridge() { return *_Ros; }
 
 	UWorld* _World = nullptr;
 
@@ -258,11 +260,14 @@ public:
 		UE_LOG(LogROS, Display, TEXT("UROSIntegrationCore ~Impl() "));
 		//_World = nullptr;
 		_SpawnManager = nullptr;
+		if(_Ros) delete _Ros;
+		if(_WebsocketConnection) delete _WebsocketConnection;
+		if (_TCPConnection) delete _TCPConnection;
 	}
 
 	bool IsHealthy() const
 	{
-		return _Connection.IsHealthy() && _Ros.IsHealthy();
+		return ((_TCPConnection != nullptr && _TCPConnection->IsHealthy()) || (_WebsocketConnection != nullptr && _WebsocketConnection->IsHealthy())) && _Ros != nullptr && _Ros->IsHealthy();
 	}
 
 	void SetWorld(UWorld* World)
@@ -275,15 +280,25 @@ public:
 		_SpawnManager = SpawnManager;
 	}
 
-	bool Init(FString ROSBridgeHost, int32 ROSBridgePort, bool bson_test_mode)
+	bool Init(FString protocol, FString ROSBridgeHost, int32 ROSBridgePort, bool bson_test_mode)
 	{
 		_bson_test_mode = bson_test_mode;
 
-		if (bson_test_mode) {
-			_Ros.enable_bson_mode();
+		if (protocol == "ws") {
+			_WebsocketConnection = new WebsocketConnection();
+			_Ros = new rosbridge2cpp::ROSBridge(*_WebsocketConnection);
+		} else if (protocol == "tcp") {
+			_TCPConnection = new TCPConnection();
+			_Ros = new rosbridge2cpp::ROSBridge(*_TCPConnection);
+		} else {
+			UE_LOG(LogROS, Error, TEXT("Protocol not supported"));
 		}
 
-		bool ConnectionSuccessful = _Ros.Init(TCHAR_TO_UTF8(*ROSBridgeHost), ROSBridgePort);
+		if (bson_test_mode) {
+			_Ros->enable_bson_mode();
+		}
+
+		bool ConnectionSuccessful = _Ros->Init(TCHAR_TO_UTF8(*ROSBridgeHost), ROSBridgePort);
 		if (!ConnectionSuccessful) {
 			return false;
 		}
@@ -298,11 +313,11 @@ public:
 	{
 		// Listen to the object spawning thread
 		_SpawnMessageListener = std::unique_ptr<rosbridge2cpp::ROSTopic>(
-			new rosbridge2cpp::ROSTopic(_Ros, "/unreal_ros/spawn_objects", "visualization_msgs/Marker"));
+			new rosbridge2cpp::ROSTopic(GetBridge(), "/unreal_ros/spawn_objects", "visualization_msgs/Marker"));
 		_SpawnMessageListener->Subscribe(std::bind(&UImpl::Impl::SpawnMessageCallback, this, std::placeholders::_1));
 
 		_SpawnArrayMessageListener = std::unique_ptr<rosbridge2cpp::ROSTopic>(
-			new rosbridge2cpp::ROSTopic(_Ros, "/unreal_ros/spawn_objects_array", "visualization_msgs/MarkerArray"));
+			new rosbridge2cpp::ROSTopic(GetBridge(), "/unreal_ros/spawn_objects_array", "visualization_msgs/MarkerArray"));
 		_SpawnArrayMessageListener->Subscribe(
 			std::bind(&UImpl::Impl::SpawnArrayMessageCallback, this, std::placeholders::_1));
 
@@ -369,7 +384,7 @@ UROSIntegrationCore::~UROSIntegrationCore()
 	UE_LOG(LogROS, Display, TEXT("UROSIntegrationCore ~UROSIntegrationCore() "));
 }
 
-bool UROSIntegrationCore::Init(FString ROSBridgeHost, int32 ROSBridgePort) {
+bool UROSIntegrationCore::Init(FString protocol, FString ROSBridgeHost, int32 ROSBridgePort) {
 	UE_LOG(LogROS, Verbose, TEXT("CALLING INIT ON RIC IMPL()!"));
 
 	if(!_SpawnManager)	_SpawnManager = NewObject<USpawnManager>(USpawnManager::StaticClass()); // moved here from UImpl::Init()
@@ -381,7 +396,7 @@ bool UROSIntegrationCore::Init(FString ROSBridgeHost, int32 ROSBridgePort) {
 		_Implementation->Init();
 		_Implementation->SetImplSpawnManager(_SpawnManager);
 	}
-	return _Implementation->Get()->Init(ROSBridgeHost, ROSBridgePort, _bson_test_mode);
+	return _Implementation->Get()->Init(protocol, ROSBridgeHost, ROSBridgePort, _bson_test_mode);
 }
 
 

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -59,6 +59,7 @@ void UROSIntegrationGameInstance::Init()
 			if (OverrideParams)
 			{
 				UE_LOG(LogROS, Display, TEXT("ROSIntegrationGameInstance::Init() - Found AROSBridgeParamOverride to override ROS connection parameters."));
+				ROSBridgeServerProtocol = OverrideParams->ROSBridgeServerProtocol;
 				ROSBridgeServerHost = OverrideParams->ROSBridgeServerHost;
 				ROSBridgeServerPort = OverrideParams->ROSBridgeServerPort;
 				bConnectToROS = OverrideParams->bConnectToROS;
@@ -70,7 +71,7 @@ void UROSIntegrationGameInstance::Init()
 		}
 
 		ROSIntegrationCore = NewObject<UROSIntegrationCore>(UROSIntegrationCore::StaticClass()); // ORIGINAL 
-		bIsConnected = ROSIntegrationCore->Init(ROSBridgeServerHost, ROSBridgeServerPort);
+		bIsConnected = ROSIntegrationCore->Init(ROSBridgeServerProtocol, ROSBridgeServerHost, ROSBridgeServerPort);
 
 		if (!bTimerSet)
 		{

--- a/Source/ROSIntegration/Private/Service.cpp
+++ b/Source/ROSIntegration/Private/Service.cpp
@@ -45,7 +45,7 @@ public:
 		_ServiceName = ServiceName;
 		_ServiceType = ServiceType;
 
-		_ROSService = new rosbridge2cpp::ROSService(Ric->_Implementation->Get()->_Ros, TCHAR_TO_UTF8(*ServiceName), TCHAR_TO_UTF8(*ServiceType));
+		_ROSService = new rosbridge2cpp::ROSService(Ric->_Implementation->Get()->GetBridge(), TCHAR_TO_UTF8(*ServiceName), TCHAR_TO_UTF8(*ServiceType));
 
 		// Construct static ConverterMaps
 		if (RequestConverterMap.Num() == 0)
@@ -134,7 +134,7 @@ public:
 				return;
 			}
 
-			_Ric->_Implementation->Get()->_Ros.SendMessage(response);
+			_Ric->_Implementation->Get()->GetBridge().SendMessage(response);
 		};
 
 		if (_HandleRequestsInGameThread) {

--- a/Source/ROSIntegration/Private/Topic.cpp
+++ b/Source/ROSIntegration/Private/Topic.cpp
@@ -145,7 +145,7 @@ public:
 		}
 		_Converter = *Converter;
 
-		_ROSTopic = new rosbridge2cpp::ROSTopic(Ric->_Implementation->Get()->_Ros, TCHAR_TO_UTF8(*Topic), TCHAR_TO_UTF8(*MessageType), QueueSize);
+		_ROSTopic = new rosbridge2cpp::ROSTopic(Ric->_Implementation->Get()->GetBridge(), TCHAR_TO_UTF8(*Topic), TCHAR_TO_UTF8(*MessageType), QueueSize);
 	}
 
 	void MessageCallback(const ROSBridgePublishMsg &message)

--- a/Source/ROSIntegration/Private/rosbridge2cpp/WebsocketConnection.cpp
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/WebsocketConnection.cpp
@@ -1,0 +1,160 @@
+#include "WebsocketConnection.h"
+#include <iostream>
+#include "ROSIntegrationCore.h"
+#include "WebSocketsModule.h"  //moduel used to create websocket object in init 
+#include <iomanip>
+
+#include <Interfaces/IPv4/IPv4Address.h>
+#if ENGINE_MINOR_VERSION < 23
+#include <IPAddress.h>
+#endif
+#include <Serialization/ArrayReader.h>
+#include <SocketSubsystem.h>
+
+WebsocketConnection::WebsocketConnection() : _incoming_message_callback(nullptr), incoming_message_callback_bson_(nullptr), _error_callback(nullptr) {
+}
+
+WebsocketConnection::~WebsocketConnection() {
+	WebSocket->OnConnectionError().RemoveAll(this);
+	WebSocket->OnClosed().RemoveAll(this);
+	WebSocket->OnMessage().RemoveAll(this);
+	WebSocket->OnRawMessage().RemoveAll(this);
+	ReportError(rosbridge2cpp::TransportError::R2C_CONNECTION_CLOSED);
+	WebSocket->Close();
+}
+
+bool WebsocketConnection::Init(std::string ip_addr, int port)
+{
+
+	//LWS throttles messages by default, check to see if it has been overridden
+	double ThreadTargetFrameTimeInSeconds = 0.0;
+	bool setGlobally = GConfig->GetDouble(TEXT("WebSockets.LibWebSockets"), TEXT("ThreadTargetFrameTimeInSeconds"), ThreadTargetFrameTimeInSeconds, GEngineIni);
+
+	if (!FModuleManager::Get().IsModuleLoaded("WebSockets"))
+	{
+		//If throttling not overridden by the .ini, set to 0 before initializing the module
+		if (!setGlobally) {
+			GConfig->SetDouble(TEXT("WebSockets.LibWebSockets"), TEXT("ThreadTargetFrameTimeInSeconds"), 0.0, GEngineIni);
+		} else if (ThreadTargetFrameTimeInSeconds > 0.0) {
+			UE_LOG(LogROS, Warning, TEXT("WebSockets.LibWebSockets.ThreadTargetFrameTimeInSeconds is set to be > 0.0. You may experience ROS lag."));
+		}
+
+		FModuleManager::Get().LoadModule("Websockets");
+	} else {
+		//Sanity check thread throttling
+		if (!setGlobally || ThreadTargetFrameTimeInSeconds > 0.0) {
+			UE_LOG(LogROS, Warning, TEXT("WebSockets.LibWebSockets.ThreadTargetFrameTimeInSeconds is either not set, or set to be > 0.0. You may experience ROS lag."));
+		}
+	}
+
+
+	//Connect to Websocket
+	TArray< FStringFormatArg > args;
+	args.Add(FStringFormatArg(ip_addr.c_str()));
+	args.Add(FStringFormatArg(port));
+	const FString ServerURL = FString::Format(TEXT("ws://{0}:{1}"), args);
+	UE_LOG(LogROS, Display, TEXT("Connecting to: %s"), *ServerURL);
+
+	WebSocket = FWebSocketsModule::Get().CreateWebSocket(ServerURL);
+
+	//Set up callbacks
+	WebSocket->OnConnectionError().AddRaw(this, &WebsocketConnection::OnConnectionError);
+	WebSocket->OnClosed().AddRaw(this, &WebsocketConnection::OnClosed);
+	WebSocket->OnMessage().AddRaw(this, &WebsocketConnection::OnMessage);
+	WebSocket->OnRawMessage().AddRaw(this, &WebsocketConnection::OnRawMessage);
+
+	WebSocket->Connect();
+
+	return true;
+}
+
+void WebsocketConnection::OnConnectionError(const FString& Error) {
+	UE_LOG(LogROS, Display, TEXT("WebSocket Connect Error"));
+	ReportError(rosbridge2cpp::TransportError::R2C_SOCKET_ERROR);
+}
+
+void WebsocketConnection::OnClosed(int32 StatusCode, const FString& Reason, bool bWasClean) {
+	UE_LOG(LogROS, Warning, TEXT("Connection closed: %d:%s. Clean: %d"), StatusCode, *Reason, bWasClean);
+	ReportError(rosbridge2cpp::TransportError::R2C_CONNECTION_CLOSED);
+}
+
+bool WebsocketConnection::SendMessage(std::string data)
+{
+	//Data is already UTF-8, no conversion to UE4 string is necessary
+	WebSocket->Send(data.c_str(), data.size(), false);
+	return true;
+}
+
+bool WebsocketConnection::SendMessage(const uint8_t* data, unsigned int length)
+{
+	WebSocket->Send(data, length, true);
+	return true;
+}
+
+void WebsocketConnection::OnRawMessage(const void* data, size_t size, size_t bytes_remaining)
+{
+	if (bytes_remaining > 0) {
+		UE_LOG(LogROS, Warning, TEXT("Websocket message fragments not supported - Ignoring message"));
+		return;
+	}
+	bson_t b;
+	if (!bson_init_static(&b, reinterpret_cast<const uint8_t*>(data), size)) {
+		UE_LOG(LogROS, Error, TEXT("Error on BSON parse - Ignoring message"));
+	} else if (incoming_message_callback_bson_) {
+		incoming_message_callback_bson_(b);
+	}
+}
+
+void WebsocketConnection::OnMessage(const FString& msg) {
+	json j;
+	try {
+		j.Parse(TCHAR_TO_ANSI(*msg)); //convert to UTF-8 and then reinterpret_cast the pointer to char *
+
+		if (_incoming_message_callback)
+			_incoming_message_callback(j);
+	}
+	catch (...) {
+		UE_LOG(LogROS, Error, TEXT("Failed to parse JSON - Ignoring message"));
+	}
+}
+
+void WebsocketConnection::RegisterIncomingMessageCallback(std::function<void(json&)> fun)
+{
+	_incoming_message_callback = fun;
+}
+
+void WebsocketConnection::RegisterIncomingMessageCallback(std::function<void(bson_t&)> fun)
+{
+	incoming_message_callback_bson_ = fun;
+}
+
+void WebsocketConnection::RegisterErrorCallback(std::function<void(rosbridge2cpp::TransportError)> fun)
+{
+	_error_callback = fun;
+}
+
+void WebsocketConnection::ReportError(rosbridge2cpp::TransportError err)
+{
+	if (_error_callback)
+		_error_callback(err);
+}
+
+
+void WebsocketConnection::SetTransportMode(rosbridge2cpp::ITransportLayer::TransportMode mode)
+{
+	switch (mode) {
+	case rosbridge2cpp::ITransportLayer::JSON:
+		bson_only_mode_ = false;
+		break;
+	case rosbridge2cpp::ITransportLayer::BSON:
+		bson_only_mode_ = true;
+		break;
+	default:
+		UE_LOG(LogROS, Error, TEXT("Given TransportMode not implemented!"));
+	}
+}
+
+bool WebsocketConnection::IsHealthy() const
+{
+	return WebSocket->IsConnected();
+}

--- a/Source/ROSIntegration/Private/rosbridge2cpp/WebsocketConnection.h
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/WebsocketConnection.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <functional> // std::function
+
+#include <CoreMinimal.h>
+
+//#include Websocket stuff
+#include <SocketSubsystem.h>
+#include <Sockets.h>
+#include "itransport_layer.h"
+#include "types.h"
+//
+
+#include "rapidjson/document.h"
+using json = rapidjson::Document;
+
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include "IWebSocket.h"
+
+#pragma warning(disable:4265)
+class WebsocketConnection : public rosbridge2cpp::ITransportLayer {
+public:
+	WebsocketConnection();	//constructor
+	~WebsocketConnection(); //deconstructor
+
+
+	bool Init(std::string ip_addr, int port);
+	bool SendMessage(std::string data);
+	bool SendMessage(const uint8_t* data, unsigned int length);
+	void RegisterIncomingMessageCallback(std::function<void(json&)> fun);
+	void RegisterIncomingMessageCallback(std::function<void(bson_t&)> fun);
+	void RegisterErrorCallback(std::function<void(rosbridge2cpp::TransportError)> fun);
+	void ReportError(rosbridge2cpp::TransportError err);
+	void SetTransportMode(rosbridge2cpp::ITransportLayer::TransportMode);
+
+	bool IsHealthy() const;
+
+private:
+	void OnConnectionError(const FString& Error);
+	void OnClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
+	void OnRawMessage(const void*, size_t size, size_t bytes_remaining);
+	void OnMessage(const FString& msg);
+
+
+	TSharedPtr<IWebSocket> WebSocket;
+
+	bool bson_only_mode_ = false;
+	std::function<void(json&)> _incoming_message_callback;
+	std::function<void(bson_t&)> incoming_message_callback_bson_;
+	std::function<void(rosbridge2cpp::TransportError)> _error_callback;
+};
+#pragma warning(default:4265)

--- a/Source/ROSIntegration/ROSIntegration.Build.cs
+++ b/Source/ROSIntegration/ROSIntegration.Build.cs
@@ -56,7 +56,8 @@ public class ROSIntegration : ModuleRules
 				"CoreUObject",
 				"Engine",
 				"Sockets",
-				"Networking"
+				"Networking",
+				"WebSockets"
 				// ... add private dependencies that you statically link with here ...
 			}
 		);


### PR DESCRIPTION
* Added WebsocketConnection object.
* Added LWS parameters to engine.ini (otherwise websocket messages get throttled to 30hz)
* Changed UImpl to have a rosbridge2cpp::ROSBridge pointer and updated all references.
* Added ROSBridgeServerProtocol variable to UROSIntegrationGameInstance & AROSBridgeParamOverride
* Changed the Init() function call chain to pass protocol variable along

Tested on UE4 4.27, ROS1 Melodic (Python 2) on Ubuntu 18.04, using rosbridge_suite 0.11.10

Note: websocket_external_port must be set on the rosbridge server: `roslaunch rosbridge_server rosbridge_websocket.launch websocket_external_port:=80`