### PR TITLE
Fix to avoid potential shutdown crash

### DIFF
--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -13,8 +13,8 @@ static void UnsubscribeAndUnadvertiseAllTopics()
 	for (TObjectIterator<UTopic> It; It; ++It)
 	{
 		UTopic* Topic = *It;
+		Topic->Unadvertise(); // to make sure everything all topics are unadvertised on ROS side
 		Topic->Unsubscribe(); // to prevent messages arriving during shutdown from triggering subscription callbacks
-		Topic->Unadvertise(); // just in case.. maybe not necessary?
 		Topic->MarkAsDisconnected();
 	}
 }

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -13,7 +13,7 @@ static void UnsubscribeAndUnadvertiseAllTopics()
 	for (TObjectIterator<UTopic> It; It; ++It)
 	{
 		UTopic* Topic = *It;
-		Topic->Unadvertise(); // to make sure everything all topics are unadvertised on ROS side
+		Topic->Unadvertise(); // to make sure all topics are unadvertised on ROS side
 		Topic->Unsubscribe(); // to prevent messages arriving during shutdown from triggering subscription callbacks
 		Topic->MarkAsDisconnected();
 	}

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -8,6 +8,17 @@
 #include "Kismet/GameplayStatics.h"
 
 
+static void UnsubscribeAndUnadvertiseAllTopics()
+{
+	for (TObjectIterator<UTopic> It; It; ++It)
+	{
+		UTopic* Topic = *It;
+		Topic->Unsubscribe(); // to prevent messages arriving during shutdown from triggering subscription callbacks
+		Topic->Unadvertise(); // just in case.. maybe not necessary?
+		Topic->MarkAsDisconnected();
+	}
+}
+
 static void MarkAllROSObjectsAsDisconnected()
 {
 	for (TObjectIterator<UTopic> It; It; ++It)
@@ -187,6 +198,7 @@ void UROSIntegrationGameInstance::Shutdown()
 			FWorldDelegates::OnWorldTickStart.RemoveAll(this);
 		}
 
+		UnsubscribeAndUnadvertiseAllTopics(); // make sure no subscription callbacks are fired during shutdown
 		MarkAllROSObjectsAsDisconnected(); // moved here from UROSIntegrationGameInstance::BeginDestroy()
 
 		UE_LOG(LogROS, Display, TEXT("ROS Game Instance - shutdown done"));


### PR DESCRIPTION
There was a problem in the scenario with high frequency subscription messages. If a message arrived after UROSIntegrationGameInstance::Shutdown(), it would try to trigger an invocation of a subscription callback during an unsafe topic state, causing a crash (not in the callback implementation, but in ROSIntegration).  Therefore, unsubribe all topics in beginning of shutdown to ignore messages arriving after.

Also, at the same moment, unadvertise all topics.