### PR TITLE
Fixed ROSTime Advancement Issue, Added Nullptr Checks, Autoshutdown ROS Objects, Added New Features

### DIFF
--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -49,6 +49,8 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ROS")
 	bool bCheckHealth = true;
 
+	FOnROSConnectionChange OnROSConnectionChange;
+
 protected:
 	void CheckROSBridgeHealth();
 
@@ -73,8 +75,6 @@ protected:
 	class UTopic* ClockTopic = nullptr;
 
 	bool bAddedOnWorldTickDelegate = false;
-
-	FOnROSConnectionChange OnROSConnectionChange;
 };
 
 

--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -9,7 +9,7 @@
 #include "ROSIntegrationGameInstance.generated.h"
 
 // Lets the game instance share with any bound delegates that the ROS connection status has changed
-DECLARE_MULTICAST_DELEGATE_OneParam(FOnROSConnectionChange, bool /*IsConnected*/);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnROSConnectionStatus, bool /*IsConnected*/);
 
 UCLASS()
 class ROSINTEGRATION_API UROSIntegrationGameInstance : public UGameInstance
@@ -49,7 +49,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ROS")
 	bool bCheckHealth = true;
 
-	FOnROSConnectionChange OnROSConnectionChange;
+	FOnROSConnectionStatus OnROSConnectionStatus;
+
+	bool IsROSBridgeHealthy() const;
 
 protected:
 	void CheckROSBridgeHealth();

--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -51,8 +51,6 @@ public:
 
 	FOnROSConnectionStatus OnROSConnectionStatus;
 
-	bool IsROSBridgeHealthy() const;
-
 protected:
 	void CheckROSBridgeHealth();
 

--- a/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
+++ b/Source/ROSIntegration/Classes/ROSIntegrationGameInstance.h
@@ -8,6 +8,9 @@
 
 #include "ROSIntegrationGameInstance.generated.h"
 
+// Lets the game instance share with any bound delegates that the ROS connection status has changed
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnROSConnectionChange, bool /*IsConnected*/);
+
 UCLASS()
 class ROSINTEGRATION_API UROSIntegrationGameInstance : public UGameInstance
 {
@@ -49,6 +52,10 @@ public:
 protected:
 	void CheckROSBridgeHealth();
 
+	void ShutdownAllROSObjects();
+
+	void MarkAllROSObjectsAsDisconnected();
+
 #if ENGINE_MINOR_VERSION > 23 || ENGINE_MAJOR_VERSION >4
 	virtual void OnWorldTickStart(UWorld * World, ELevelTick TickType, float DeltaTime);
 #else 
@@ -64,6 +71,10 @@ protected:
 
 	UPROPERTY()
 	class UTopic* ClockTopic = nullptr;
+
+	bool bAddedOnWorldTickDelegate = false;
+
+	FOnROSConnectionChange OnROSConnectionChange;
 };
 
 

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -8,39 +8,6 @@
 #include "Kismet/GameplayStatics.h"
 
 
-static void ShutdownAllROSObjects()
-{
-	for (TObjectIterator<UTopic> It; It; ++It)
-	{
-		UTopic* Topic = *It;
-		Topic->Unadvertise(); // Must come before unsubscribe becasue unsubscribe can potentially set _ROSTopic to null
-		Topic->Unsubscribe();
-		Topic->MarkAsDisconnected();
-	}
-	for (TObjectIterator<UService> It; It; ++It)
-	{
-		UService* Service = *It;
-		Service->Unadvertise();
-		Service->MarkAsDisconnected();   
-	}
-}
-
-static void MarkAllROSObjectsAsDisconnected()
-{
-	for (TObjectIterator<UTopic> It; It; ++It)
-	{
-		UTopic* Topic = *It;
-
-		Topic->MarkAsDisconnected();  
-	}
-	for (TObjectIterator<UService> It; It; ++It)
-	{
-		UService* Service = *It;
-
-		Service->MarkAsDisconnected();   
-	}
-}
-
 void UROSIntegrationGameInstance::Init()
 {
 	Super::Init();
@@ -97,6 +64,10 @@ void UROSIntegrationGameInstance::Init()
 
 		if (bIsConnected)
 		{
+			if (OnROSConnectionChange.IsBound())
+			{
+				OnROSConnectionChange.Broadcast(true); // Notify bound functions that we are connected to rosbridge
+			}
 			UWorld* CurrentWorld = GetWorld();
 			if (CurrentWorld)
 			{
@@ -123,7 +94,11 @@ void UROSIntegrationGameInstance::Init()
 			FROSTime::SetUseSimTime(true);
 			FROSTime::SetSimTime(now);
 
-			FWorldDelegates::OnWorldTickStart.AddUObject(this, &UROSIntegrationGameInstance::OnWorldTickStart);
+			if (!bAddedOnWorldTickDelegate)
+			{
+				FWorldDelegates::OnWorldTickStart.AddUObject(this, &UROSIntegrationGameInstance::OnWorldTickStart);
+				bAddedOnWorldTickDelegate = true;
+			}
 
 			ClockTopic = NewObject<UTopic>(UTopic::StaticClass()); // ORIGINAL
 
@@ -146,6 +121,10 @@ void UROSIntegrationGameInstance::CheckROSBridgeHealth()
 	if (bIsConnected)
 	{
 		UE_LOG(LogROS, Error, TEXT("Connection to rosbridge %s:%u was interrupted."), *ROSBridgeServerHost, ROSBridgeServerPort);
+		if (OnROSConnectionChange.IsBound())
+		{
+			OnROSConnectionChange.Broadcast(false); // Notify bound functions that we lost rosbridge connection
+		}
 	}
 
 	// reconnect again
@@ -189,6 +168,49 @@ void UROSIntegrationGameInstance::CheckROSBridgeHealth()
 	}
 
 	UE_LOG(LogROS, Display, TEXT("Successfully reconnected to rosbridge %s:%u."), *ROSBridgeServerHost, ROSBridgeServerPort);
+	if (OnROSConnectionChange.IsBound())
+	{
+		OnROSConnectionChange.Broadcast(true); // Notify bound functions that we are connected to rosbridge again
+	}
+}
+
+void UROSIntegrationGameInstance::ShutdownAllROSObjects()
+{
+	for (TObjectIterator<UTopic> It; It; ++It)
+	{
+		UTopic* Topic = *It;
+		if (bIsConnected)
+		{
+			Topic->Unadvertise(); // Must come before unsubscribe becasue unsubscribe can potentially set _ROSTopic to null
+			Topic->Unsubscribe();
+		}
+		Topic->MarkAsDisconnected();
+	}
+	for (TObjectIterator<UService> It; It; ++It)
+	{
+		UService* Service = *It;
+		if (bIsConnected)
+		{
+			Service->Unadvertise();
+		}
+		Service->MarkAsDisconnected();   
+	}
+}
+
+void UROSIntegrationGameInstance::MarkAllROSObjectsAsDisconnected()
+{
+	for (TObjectIterator<UTopic> It; It; ++It)
+	{
+		UTopic* Topic = *It;
+
+		Topic->MarkAsDisconnected();  
+	}
+	for (TObjectIterator<UService> It; It; ++It)
+	{
+		UService* Service = *It;
+
+		Service->MarkAsDisconnected();   
+	}
 }
 
 // N.B.: from log, first comes Shutdown() and then BeginDestroy()

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -107,7 +107,10 @@ void UROSIntegrationGameInstance::Init()
 
 bool UROSIntegrationGameInstance::IsROSBridgeHealthy() const
 {
-	return bIsConnected && ROSIntegrationCore->IsHealthy();
+	if (bIsConnected && ROSIntegrationCore->IsHealthy())
+		return true;
+	else
+		return false;
 }
 
 void UROSIntegrationGameInstance::CheckROSBridgeHealth()

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -105,14 +105,6 @@ void UROSIntegrationGameInstance::Init()
 	}
 }
 
-bool UROSIntegrationGameInstance::IsROSBridgeHealthy() const
-{
-	if (bIsConnected && ROSIntegrationCore->IsHealthy())
-		return true;
-	else
-		return false;
-}
-
 void UROSIntegrationGameInstance::CheckROSBridgeHealth()
 {
 	if (!bCheckHealth) return; 

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -8,14 +8,20 @@
 #include "Kismet/GameplayStatics.h"
 
 
-static void UnsubscribeAndUnadvertiseAllTopics()
+static void ShutdownAllROSObjects()
 {
 	for (TObjectIterator<UTopic> It; It; ++It)
 	{
 		UTopic* Topic = *It;
-		Topic->Unadvertise(); // to make sure all topics are unadvertised on ROS side
-		Topic->Unsubscribe(); // to prevent messages arriving during shutdown from triggering subscription callbacks
+		Topic->Unadvertise(); // Must come before unsubscribe becasue unsubscribe can potentially set _ROSTopic to null
+		Topic->Unsubscribe();
 		Topic->MarkAsDisconnected();
+	}
+	for (TObjectIterator<UService> It; It; ++It)
+	{
+		UService* Service = *It;
+		Service->Unadvertise();
+		Service->MarkAsDisconnected();   
 	}
 }
 
@@ -198,7 +204,7 @@ void UROSIntegrationGameInstance::Shutdown()
 			FWorldDelegates::OnWorldTickStart.RemoveAll(this);
 		}
 
-		UnsubscribeAndUnadvertiseAllTopics(); // make sure no subscription callbacks are fired during shutdown
+		ShutdownAllROSObjects(); // Stop all ROS objects from advertising, publishing, and subscribing
 		MarkAllROSObjectsAsDisconnected(); // moved here from UROSIntegrationGameInstance::BeginDestroy()
 
 		UE_LOG(LogROS, Display, TEXT("ROS Game Instance - shutdown done"));

--- a/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
+++ b/Source/ROSIntegration/Private/ROSIntegrationGameInstance.cpp
@@ -64,10 +64,6 @@ void UROSIntegrationGameInstance::Init()
 
 		if (bIsConnected)
 		{
-			if (OnROSConnectionChange.IsBound())
-			{
-				OnROSConnectionChange.Broadcast(true); // Notify bound functions that we are connected to rosbridge
-			}
 			UWorld* CurrentWorld = GetWorld();
 			if (CurrentWorld)
 			{
@@ -109,21 +105,30 @@ void UROSIntegrationGameInstance::Init()
 	}
 }
 
+bool UROSIntegrationGameInstance::IsROSBridgeHealthy() const
+{
+	return bIsConnected && ROSIntegrationCore->IsHealthy();
+}
+
 void UROSIntegrationGameInstance::CheckROSBridgeHealth()
 {
 	if (!bCheckHealth) return; 
 
 	if (bIsConnected && ROSIntegrationCore->IsHealthy())
 	{
+		if (OnROSConnectionStatus.IsBound())
+		{
+			OnROSConnectionStatus.Broadcast(true); // Notify bound functions that we are connected to rosbridge
+		}
 		return;
 	}
 
 	if (bIsConnected)
 	{
 		UE_LOG(LogROS, Error, TEXT("Connection to rosbridge %s:%u was interrupted."), *ROSBridgeServerHost, ROSBridgeServerPort);
-		if (OnROSConnectionChange.IsBound())
+		if (OnROSConnectionStatus.IsBound())
 		{
-			OnROSConnectionChange.Broadcast(false); // Notify bound functions that we lost rosbridge connection
+			OnROSConnectionStatus.Broadcast(false); // Notify bound functions that we lost rosbridge connection
 		}
 	}
 
@@ -168,10 +173,6 @@ void UROSIntegrationGameInstance::CheckROSBridgeHealth()
 	}
 
 	UE_LOG(LogROS, Display, TEXT("Successfully reconnected to rosbridge %s:%u."), *ROSBridgeServerHost, ROSBridgeServerPort);
-	if (OnROSConnectionChange.IsBound())
-	{
-		OnROSConnectionChange.Broadcast(true); // Notify bound functions that we are connected to rosbridge again
-	}
 }
 
 void UROSIntegrationGameInstance::ShutdownAllROSObjects()

--- a/Source/ROSIntegration/Private/ROSTime.cpp
+++ b/Source/ROSIntegration/Private/ROSTime.cpp
@@ -25,3 +25,10 @@ void FROSTime::SetSimTime(const FROSTime& time)
 	ROSTime::sim_time.sec_ = time._Sec;
 	ROSTime::sim_time.nsec_ = time._NSec;
 }
+
+double FROSTime::GetTimeDelta(const FROSTime& Time1, const FROSTime& Time2)
+{
+	double SecDelta = std::chrono::duration_cast<std::chrono::duration<double> >(std::chrono::seconds(Time2._Sec) - std::chrono::seconds(Time1._Sec)).count();
+	double NsecDelta = std::chrono::duration_cast<std::chrono::duration<double> >(std::chrono::nanoseconds(Time2._NSec) - std::chrono::nanoseconds(Time1._NSec)).count();
+	return SecDelta + NsecDelta;
+}

--- a/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/TCPConnection.cpp
@@ -54,6 +54,12 @@ bool TCPConnection::Init(std::string ip_addr, int port)
 
 bool TCPConnection::SendMessage(std::string data)
 {
+	if (!_sock)
+	{
+		UE_LOG(LogROS, Error, TEXT("TCPConnection::SendMessage() - Trying to send string message when socket is nullptr."));
+		return false;
+	}
+
 	// std::string msg = "{\"args\":{\"a\":1,\"b\":2},\"id\":\"call_service:/add_two_ints:23\",\"op\":\"call_service\",\"service\":\"/add_two_ints\"}";
 	const uint8 *byte_msg = reinterpret_cast<const uint8*>(data.c_str());
 	int32 bytes_sent = 0;
@@ -68,6 +74,12 @@ bool TCPConnection::SendMessage(std::string data)
 
 bool TCPConnection::SendMessage(const uint8_t *data, unsigned int length)
 {
+	if (!_sock)
+	{
+		UE_LOG(LogROS, Error, TEXT("TCPConnection::SendMessage() - Trying to send binary message when socket is nullptr."));
+		return false;
+	}
+	
 	// Simple checksum
 	//uint16_t checksum = Fletcher16(data, length);
 

--- a/Source/ROSIntegration/Public/ROSTime.h
+++ b/Source/ROSIntegration/Public/ROSTime.h
@@ -12,6 +12,9 @@ public:
 	static void SetUseSimTime(bool bUseSimTime);
 	static void SetSimTime(const FROSTime& time);
 
+	// Get the time difference from Time1 to Time2
+	static double GetTimeDelta(const FROSTime& Time1, const FROSTime& Time2);
+
 	unsigned long _Sec;
 	unsigned long _NSec;
 };


### PR DESCRIPTION
I meant to submit this PR a while ago but didn't get around to it. I fixed some outstanding bugs and added a few features I think are quite useful.

1. When the game instance disconnects from rosbridge and then reconnects (without stopping the game), the ROSIntegrationGameInstance would re-add the same function to the global OnWorldTickStart() function, and consequently the ROSTime would advance at a faster rate. Every time it would try to reconnect it would keep adding this function, making the problem worse. I added a boolean check to ensure it only gets added once.
2. I added some nullptr checks when trying to send data over TCP. Occasionally nullptr messages would get sent when the game is stopped and then the game would freeze up.
3. I updated the auto-shutdown feature from https://github.com/code-iai/ROSIntegration/pull/178 to include services too.
4. I added a delegate to the ROSIntegrationGameInstance so that every time rosbridge discoonects or reconnects, any bound functions will get notified and can handle the situation appropriately in their own project.
5. I added a useful function to determine the time difference between two FROSTime objects.