### PR TITLE
<fix>:Tf2MsgsTFMessageConverter::ConvertOutgoingMessage message nullptr.

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
@@ -21,6 +21,7 @@ bool UTf2MsgsTFMessageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> 
 		UE_LOG(LogTemp, Warning, TEXT("No transform saved in TFMessage. Can't convert message"));
 		return false;
 	}
+	*message = bson_new();
 	_bson_append_tf2_msg(*message, CastMsg.Get());
 	return true;
 }


### PR DESCRIPTION
Can not send ROSMessages::tf2_msgs::TFMessage to ROS from UE. will throw an error of !bson_append_array_begin()

![7f3e10437785aad95aff30955beff879](https://github.com/code-iai/ROSIntegration/assets/39846986/465160f3-13f7-43da-8a16-3c9d4c22d036)

This is because the message is a null pointer and was not created properly.