### PR TITLE
bugfix: initialize tf2 bson message

### DIFF
--- a/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
+++ b/Source/ROSIntegration/Private/Conversion/Messages/tf2_msgs/Tf2MsgsTFMessageConverter.cpp
@@ -16,6 +16,7 @@ bool UTf2MsgsTFMessageConverter::ConvertIncomingMessage(const ROSBridgePublishMs
 bool UTf2MsgsTFMessageConverter::ConvertOutgoingMessage(TSharedPtr<FROSBaseMsg> BaseMsg, bson_t** message) 
 {
 	auto CastMsg = StaticCastSharedPtr<ROSMessages::tf2_msgs::TFMessage>(BaseMsg);
+	*message = bson_new();
 	if (CastMsg->transforms.Num() == 0) 
 	{
 		UE_LOG(LogTemp, Warning, TEXT("No transform saved in TFMessage. Can't convert message"));


### PR DESCRIPTION
Fixes creating outgoing TF2 message. 
Previously it was initialized to a nullptr, this is necessary, to send these types of messages.